### PR TITLE
fix: Parse returns nil node if empty string reader

### DIFF
--- a/template/parser/parser.go
+++ b/template/parser/parser.go
@@ -25,6 +25,14 @@ func NewParser(r io.Reader) *Parser {
 // Parse parses the template string and returns the corresponding ast.Node.
 func (p *Parser) Parse() (ast.Node, error) {
 	p.next()
+	if p.tok == token.EOF {
+		// empty string
+		return &ast.BasicLit{
+			ValuePos: 0,
+			Kind:     token.STRING,
+			Value:    "",
+		}, nil
+	}
 	return p.parseExpr(), p.errors.Err()
 }
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -44,6 +44,10 @@ func TestTemplate_Execute(t *testing.T) {
 			str:    "1",
 			expect: "1",
 		},
+		"empty string": {
+			str:    "",
+			expect: "",
+		},
 		"empty parameter": {
 			str:    "{{}}",
 			expect: "",


### PR DESCRIPTION
`template.Parser` could not handle a empty string.