### PR TITLE
fix(context): fix a bug

### DIFF
--- a/context/extract_test.go
+++ b/context/extract_test.go
@@ -35,8 +35,8 @@ func TestContext_ExtractKey(t *testing.T) {
 					"test": p,
 				})
 			},
-			query:  "plugins.test.Name",
-			expect: "simple",
+			query:  "plugins.test.String",
+			expect: "string",
 		},
 		"vars": {
 			ctx: func(ctx *Context) *Context {

--- a/context/plugins.go
+++ b/context/plugins.go
@@ -33,8 +33,11 @@ type plug plugin.Plugin
 // ExtractByKey implements query.KeyExtractor interface.
 func (p *plug) ExtractByKey(key string) (interface{}, bool) {
 	if sym, err := ((*plugin.Plugin)(p)).Lookup(key); err == nil {
-		// sym is a pointer to a variable or function.
-		return reflect.ValueOf(sym).Elem().Interface(), true
+		// If sym is a pointer to a variable, return the actual variable for convenience.
+		if v := reflect.ValueOf(sym); v.Kind() == reflect.Ptr {
+			return v.Elem().Interface(), true
+		}
+		return sym, true
 	}
 	return nil, false
 }

--- a/context/plugins_test.go
+++ b/context/plugins_test.go
@@ -1,0 +1,59 @@
+package context
+
+import (
+	"io"
+	"plugin"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPlug_ExtactByKey(t *testing.T) {
+	p, err := plugin.Open("../testdata/gen/plugins/simple.so")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ptrSym, err := p.Lookup("Pointer")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	tests := map[string]struct {
+		key    string
+		expect interface{}
+	}{
+		"string": {
+			key:    "String",
+			expect: "string",
+		},
+		"pointer": {
+			key:    "Pointer",
+			expect: reflect.ValueOf(ptrSym).Elem().Interface(),
+		},
+		"interface": {
+			key:    "Interface",
+			expect: io.Reader(nil),
+		},
+		"function": {
+			key:    "Function",
+			expect: "function",
+		},
+	}
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			got, ok := (*plug)(p).ExtractByKey(test.key)
+			if !ok {
+				t.Fatal("not found")
+			}
+			if f, ok := got.(func() string); ok {
+				got = f()
+			}
+			if diff := cmp.Diff(test.expect, got); diff != "" {
+				t.Errorf("differs: (-want +got)\n%s", diff)
+			}
+		})
+	}
+}

--- a/testdata/plugins/simple/main.go
+++ b/testdata/plugins/simple/main.go
@@ -1,3 +1,11 @@
 package main
 
-var Name = "simple"
+import "io"
+
+var (
+	String    = "string"
+	Pointer   = &String
+	Interface = io.Reader(nil)
+)
+
+func Function() string { return "function" }


### PR DESCRIPTION
`reflect.ValueOf(sym).Elem()` panics if `sym` is a function.