### PR TITLE
fix: use json.Number to avoid rounding error

### DIFF
--- a/assert/equal.go
+++ b/assert/equal.go
@@ -1,6 +1,7 @@
 package assert
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -11,6 +12,21 @@ import (
 // Equal returns an assertion to ensure a value equals the expected value.
 func Equal(q *query.Query, expected interface{}) Assertion {
 	return assertFunc(q, func(v interface{}) error {
+		if n, ok := v.(json.Number); ok {
+			switch expected.(type) {
+			case int, int8, int16, int32, int64:
+				i, err := n.Int64()
+				if err == nil {
+					v = i
+				}
+			case float32, float64:
+				f, err := n.Float64()
+				if err == nil {
+					v = f
+				}
+			}
+		}
+
 		if reflect.DeepEqual(v, expected) {
 			return nil
 		}

--- a/assert/equal_test.go
+++ b/assert/equal_test.go
@@ -1,6 +1,7 @@
 package assert
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
@@ -61,6 +62,21 @@ func TestEqual(t *testing.T) {
 			expected: test.UserType_CUSTOMER.String(),
 			ok:       test.UserType_CUSTOMER,
 			ng:       test.UserType_USER_TYPE_UNSPECIFIED,
+		},
+		"json.Number (string)": {
+			expected: "100",
+			ok:       json.Number("100"),
+			ng:       json.Number("0.01"),
+		},
+		"json.Number (int)": {
+			expected: 100,
+			ok:       json.Number("100"),
+			ng:       json.Number("0.01"),
+		},
+		"json.Number (float)": {
+			expected: 0.01,
+			ok:       json.Number("0.01"),
+			ng:       json.Number("100"),
 		},
 	}
 	for name, tc := range tests {

--- a/assert/not_zero.go
+++ b/assert/not_zero.go
@@ -1,6 +1,7 @@
 package assert
 
 import (
+	"encoding/json"
 	"reflect"
 
 	"github.com/pkg/errors"
@@ -10,6 +11,18 @@ import (
 // NotZero returns an assertion to ensure a value is not zero value.
 func NotZero(q *query.Query) Assertion {
 	return assertFunc(q, func(v interface{}) error {
+		if n, ok := v.(json.Number); ok {
+			if i, err := n.Int64(); err == nil {
+				if i == 0 {
+					return errors.Errorf("%s: expected not zero value", q.String())
+				}
+			}
+			if f, err := n.Float64(); err == nil {
+				if f == 0.0 {
+					return errors.Errorf("%s: expected not zero value", q.String())
+				}
+			}
+		}
 		if v == nil || reflect.DeepEqual(v, reflect.Zero(reflect.TypeOf(v)).Interface()) {
 			return errors.Errorf("%s: expected not zero value", q.String())
 		}

--- a/assert/not_zero_test.go
+++ b/assert/not_zero_test.go
@@ -1,6 +1,7 @@
 package assert
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -35,6 +36,14 @@ func TestNotZero(t *testing.T) {
 		{
 			ok: &myStruct{},
 			ng: nil,
+		},
+		{
+			ok: json.Number("1"),
+			ng: json.Number("0"),
+		},
+		{
+			ok: json.Number("1.0"),
+			ng: json.Number("0.0"),
 		},
 	}
 	for i, test := range tests {

--- a/protocol/http/unmarshaler/json.go
+++ b/protocol/http/unmarshaler/json.go
@@ -1,6 +1,7 @@
 package unmarshaler
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -19,5 +20,7 @@ func (um *jsonUnmarshaler) MediaType() string {
 
 // Unmarshal implements ResponseUnmarshaler interface.
 func (um *jsonUnmarshaler) Unmarshal(data []byte, v interface{}) error {
-	return json.Unmarshal(data, &v)
+	d := json.NewDecoder(bytes.NewReader(data))
+	d.UseNumber()
+	return d.Decode(v)
 }

--- a/protocol/http/unmarshaler/json_test.go
+++ b/protocol/http/unmarshaler/json_test.go
@@ -1,0 +1,49 @@
+package unmarshaler
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/zoncoen/query-go"
+
+	"github.com/zoncoen/scenarigo/assert"
+)
+
+func TestJSON_Unmarshal_BigInt(t *testing.T) {
+	in := 8608570626085064778
+	b := []byte(fmt.Sprintf(`{"id": %d}`, in))
+	var v interface{}
+	um := &jsonUnmarshaler{}
+	if err := um.Unmarshal(b, &v); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expect map[string]interface{} but got %T", v)
+	}
+	out, ok := m["id"]
+	if !ok {
+		t.Fatal("id not found")
+	}
+
+	if err := assert.Equal(query.New(), in).Assert(out); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	expect := jsonString(t, in)
+	got := jsonString(t, out)
+	if got != expect {
+		t.Errorf("expect %s but got %s", expect, got)
+	}
+}
+
+func jsonString(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal: %s", err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
## What

Use `json.Decoder` with `UseNumber` option to decode JSON response.

## Why

`json.Unmarshal` unmarshals all JSON numbers into an `interface{}` as a `float64` by default.
It may cause a rounding error when the number is the greater than 2^53 (9007199254740992).