### PR TITLE
test: don't add duration to fix unstable tests

### DIFF
--- a/reporter/reporter_test.go
+++ b/reporter/reporter_test.go
@@ -451,6 +451,7 @@ FAIL
 			var b bytes.Buffer
 			Run(func(r Reporter) {
 				rptr := pr(t, r)
+				rptr.disableAddDuration = true
 				test.f(t, rptr)
 			}, WithWriter(&b))
 			if diff := cmp.Diff(test.expect, "\n"+b.String()); diff != "" {


### PR DESCRIPTION
The tests are unstable on CI ubuntu-latest. (e.g. https://github.com/zoncoen/scenarigo/pull/26/checks?check_run_id=666266821