### PR TITLE
Fix ctx.Response() for http protocol

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/fatih/structtag v1.0.0 // indirect
 	github.com/git-chglog/git-chglog v0.0.0-20200414013904-db796966b373
-	github.com/goccy/go-yaml v1.7.5
+	github.com/goccy/go-yaml v1.7.7
 	github.com/golang/mock v1.4.3
 	github.com/golang/protobuf v1.3.5
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8c
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
-github.com/goccy/go-yaml v1.7.5 h1:dWvj+p3BG11S/GlUzwzt1WZz0lhBTzTIDtmXT/ZOaPY=
-github.com/goccy/go-yaml v1.7.5/go.mod h1:wS4gNoLalDSJxo/SpngzPQ2BN4uuZVLCmbM4S3vd4+Y=
+github.com/goccy/go-yaml v1.7.7 h1:8dkACh8fnLQYdC+XAhYL4x5R7xw5bOBTTZRdt/HBGfQ=
+github.com/goccy/go-yaml v1.7.7/go.mod h1:wS4gNoLalDSJxo/SpngzPQ2BN4uuZVLCmbM4S3vd4+Y=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=

--- a/protocol/grpc/request.go
+++ b/protocol/grpc/request.go
@@ -127,7 +127,7 @@ func (r *Request) Invoke(ctx *context.Context) (*context.Context, interface{}, e
 		Body:    body,
 		rvalues: rvalues,
 	}
-	ctx = ctx.WithResponse(resp)
+	ctx = ctx.WithResponse(body)
 	if b, err := yaml.Marshal(resp); err == nil {
 		ctx.Reporter().Logf("response:\n%s", string(b))
 	} else {

--- a/protocol/grpc/request_test.go
+++ b/protocol/grpc/request_test.go
@@ -65,11 +65,7 @@ func TestRequest_Invoke(t *testing.T) {
 			if diff := cmp.Diff(req, ctx.Request()); diff != "" {
 				t.Errorf("differs: (-want +got)\n%s", diff)
 			}
-			respValue, ok := ctx.Response().(response)
-			if !ok {
-				t.Fatal("failed to get response type from ctx.Response()")
-			}
-			if diff := cmp.Diff(resp, respValue.Body); diff != "" {
+			if diff := cmp.Diff(resp, ctx.Response()); diff != "" {
 				t.Errorf("differs: (-want +got)\n%s", diff)
 			}
 		})

--- a/query/extractor/key_test.go
+++ b/query/extractor/key_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/goccy/go-yaml"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -73,6 +74,16 @@ func TestKey_Extract(t *testing.T) {
 			"key extractor": {
 				key:    "key",
 				v:      &testKeyExtractor{v: "value"},
+				expect: "value",
+			},
+			"ordered map": {
+				key: "paramA",
+				v: yaml.MapSlice{
+					{
+						Key:   "paramA",
+						Value: "value",
+					},
+				},
 				expect: "value",
 			},
 		}

--- a/test/e2e/testdata/scenarios/grpc.yaml
+++ b/test/e2e/testdata/scenarios/grpc.yaml
@@ -4,6 +4,9 @@ plugins:
   grpc: "grpc.so"
 steps:
 - title: Echo
+  bind:
+    vars:
+      mid: '{{response.messageId}}'
   vars:
     id: xxx
     message: hello

--- a/test/e2e/testdata/scenarios/http.yaml
+++ b/test/e2e/testdata/scenarios/http.yaml
@@ -1,5 +1,9 @@
 ---
 title: /echo
+anchors:
+  header: &header
+    Accept-Encoding: gzip
+    Accept: application/json
 steps:
 - title: POST /echo
   vars:
@@ -32,6 +36,7 @@ steps:
     method: POST
     url: "{{env.TEST_ADDR}}/echo"
     header:
+      <<: *header
       Authorization: "Bearer {{env.TEST_TOKEN}}"
       Content-Type: application/x-www-form-urlencoded
     body:

--- a/test/e2e/testdata/scenarios/http.yaml
+++ b/test/e2e/testdata/scenarios/http.yaml
@@ -4,6 +4,9 @@ anchors:
   header: &header
     Accept-Encoding: gzip
     Accept: application/json
+vars:
+  param:
+    paramA: world
 steps:
 - title: POST /echo
   vars:
@@ -18,11 +21,11 @@ steps:
     header:
       Authorization: "Bearer {{env.TEST_TOKEN}}"
     body:
-      message: "{{vars.message}}"
+      message: "{{vars.message}} {{vars.param.paramA}}"
   expect:
     code: 200
     header:
-      Content-Length: 30
+      Content-Length: 36
     body:
       id: "{{vars.id}}"
       message: "{{request.message}}"


### PR DESCRIPTION
- Fix `ctx.Response()` for http protocol
- Support `anchor` / `alias` in `request` and `expect`
- Fix key extractor ( forgot processing of `yaml.MapSlice` or `yaml.MapItem` )