### PR TITLE
Enable to output error with YAML even when using assert.Contains etc.

### DIFF
--- a/assert/assertion.go
+++ b/assert/assertion.go
@@ -29,7 +29,10 @@ func assertFunc(q *query.Query, f func(interface{}) error) Assertion {
 		if err != nil {
 			return errors.WithQuery(err, q)
 		}
-		return f(got)
+		if err := f(got); err != nil {
+			return errors.WithQuery(err, q)
+		}
+		return nil
 	})
 }
 

--- a/assert/equal.go
+++ b/assert/equal.go
@@ -54,9 +54,9 @@ func Equal(q *query.Query, expected interface{}) Assertion {
 					return nil
 				}
 			}
-			return errors.ErrorQueryf(q, "%s: expected %T (%+v) but got %T (%+v)", q.String(), expected, expected, v, v)
+			return errors.Errorf("%s: expected %T (%+v) but got %T (%+v)", q.String(), expected, expected, v, v)
 		}
-		return errors.ErrorQueryf(q, "%s: expected %+v but got %+v", q.String(), expected, v)
+		return errors.Errorf("%s: expected %+v but got %+v", q.String(), expected, v)
 	})
 }
 


### PR DESCRIPTION
Currently, output error without YAML in case of `assert.Contains` or `assert.NotContains` or `assert.NotZero` .
This PR fix the above problem .
