### PR TITLE
Fix processing for variadic arguments of function

### DIFF
--- a/template/template_test.go
+++ b/template/template_test.go
@@ -94,6 +94,19 @@ func TestTemplate_Execute(t *testing.T) {
 				}},
 			expect: 15,
 		},
+		"call function that have variadic arguments": {
+			str: `{{f(1, 2, 3, 4, 5)}}`,
+			data: map[string]func(int, ...float32) int{
+				"f": func(a0 int, args ...float32) int {
+					sum := a0
+					for _, a := range args {
+						sum += int(a)
+					}
+					return sum
+				}},
+			expect: 15,
+		},
+
 		"invalid function argument": {
 			str: `{{f(1, 2, 3)}}`,
 			data: map[string]func(int, int) int{
@@ -101,6 +114,18 @@ func TestTemplate_Execute(t *testing.T) {
 					return a0 + a1
 				},
 			},
+			expectError: true,
+		},
+		"invalid function argument ( variadic arguments )": {
+			str: `{{f()}}`,
+			data: map[string]func(int, ...float32) int{
+				"f": func(a0 int, args ...float32) int {
+					sum := a0
+					for _, a := range args {
+						sum += int(a)
+					}
+					return sum
+				}},
 			expectError: true,
 		},
 		"left arrow func": {


### PR DESCRIPTION
See https://golang.org/pkg/reflect/#Type
```
    // IsVariadic reports whether a function type's final input parameter
    // is a "..." parameter. If so, t.In(t.NumIn() - 1) returns the parameter's
    // implicit actual type []T.
    //
    // For concreteness, if t represents func(x int, y ... float64), then
    //
    //	t.NumIn() == 2
    //	t.In(0) is the reflect.Type for "int"
    //	t.In(1) is the reflect.Type for "[]float64"
    //	t.IsVariadic() == true
    //
    // IsVariadic panics if the type's Kind is not Func.
    IsVariadic() bool
```