### PR TITLE
Add `--dry-run` option to `scenarigo run` command

### DIFF
--- a/cmd/scenarigo/cmd/run.go
+++ b/cmd/scenarigo/cmd/run.go
@@ -17,10 +17,12 @@ var (
 
 var (
 	verbose bool
+	dryRun  bool
 )
 
 func init() {
 	runCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "print verbose log")
+	runCmd.Flags().BoolVarP(&dryRun, "dry-run", "", false, "running without request invoking and assertion")
 	rootCmd.AddCommand(runCmd)
 }
 
@@ -38,6 +40,7 @@ func run(cmd *cobra.Command, args []string) error {
 	for _, arg := range args {
 		opts = append(opts, scenarigo.WithScenarios(arg))
 	}
+	opts = append(opts, scenarigo.WithDryRun(dryRun))
 	r, err := scenarigo.NewRunner(opts...)
 	if err != nil {
 		return err

--- a/context/context.go
+++ b/context/context.go
@@ -254,6 +254,7 @@ func (c *Context) DryRun() bool {
 	return false
 }
 
+// SubTests returns all subtest names.
 func (c *Context) SubTests() []string {
 	return c.captureCtx.subtests
 }

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -23,4 +23,12 @@ func TestContext(t *testing.T) {
 			t.Fatal("failed to get enabledColor")
 		}
 	})
+	t.Run("dryRun", func(t *testing.T) {
+		ctx := FromT(t)
+		ctx = ctx.WithDryRun(true)
+		if !ctx.DryRun() {
+			t.Fatal("failed to get dryRun")
+		}
+	})
+
 }

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -30,4 +30,17 @@ func TestContext(t *testing.T) {
 			t.Fatal("failed to get dryRun")
 		}
 	})
+	t.Run("run", func(t *testing.T) {
+		ctx := FromT(t)
+		ok := ctx.Run("child", func(ctx *Context) {
+			ctx.Run("grandchild", func(ctx *Context) {})
+		})
+		if !ok {
+			t.Fatal("failed to run")
+		}
+		subtests := ctx.SubTests()
+		if len(subtests) != 2 {
+			t.Fatal("failed to get subtests")
+		}
+	})
 }

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -30,5 +30,4 @@ func TestContext(t *testing.T) {
 			t.Fatal("failed to get dryRun")
 		}
 	})
-
 }

--- a/context/template.go
+++ b/context/template.go
@@ -7,5 +7,8 @@ import (
 // ExecuteTemplate executes template strings in context.
 // nolint:stylecheck
 func (ctx *Context) ExecuteTemplate(i interface{}) (interface{}, error) {
+	if ctx.DryRun() {
+		return i, nil
+	}
 	return template.Execute(i, ctx)
 }

--- a/plugin/interface.go
+++ b/plugin/interface.go
@@ -22,5 +22,8 @@ type StepFunc func(ctx *context.Context, step *schema.Step) *context.Context
 
 // Run implements Step interface.
 func (f StepFunc) Run(ctx *context.Context, step *schema.Step) *context.Context {
+	if ctx.DryRun() {
+		return ctx
+	}
 	return f(ctx, step)
 }

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -203,8 +203,8 @@ func (r *reporter) appendChild(child *reporter) {
 	r.m.Unlock()
 }
 
-// rewrite rewrites a subname to having only printable characters and no white space.
-func rewrite(s string) string {
+// RewriteName rewrites a subname to having only printable characters and no white space.
+func RewriteName(s string) string {
 	b := make([]byte, 0, len(s))
 	for _, r := range s {
 		switch {
@@ -231,7 +231,7 @@ func (r *reporter) isRoot() bool {
 // Run may be called simultaneously from multiple goroutines,
 // but all such calls must return before the outer test function for r returns.
 func (r *reporter) Run(name string, f func(t Reporter)) bool {
-	name = rewrite(name)
+	name = RewriteName(name)
 	if r.name != "" {
 		name = fmt.Sprintf("%s/%s", r.name, name)
 	}

--- a/runner.go
+++ b/runner.go
@@ -24,6 +24,7 @@ type Runner struct {
 	pluginDir     *string
 	scenarioFiles []string
 	enabledColor  bool
+	isDryRun      bool
 }
 
 // WithPluginDir returns a option which sets plugin root directory.
@@ -58,6 +59,16 @@ func WithScenarios(paths ...string) func(*Runner) error {
 			return err
 		}
 		r.scenarioFiles = files
+		return nil
+	}
+}
+
+// WithDryRun returns a option which sets flag for dry running.
+func WithDryRun(isDryRun bool) func(*Runner) error {
+	return func(r *Runner) error {
+		if isDryRun {
+			r.isDryRun = isDryRun
+		}
 		return nil
 	}
 }
@@ -137,7 +148,8 @@ func (r *Runner) Run(ctx *context.Context) {
 	if r.pluginDir != nil {
 		ctx = ctx.WithPluginDir(*r.pluginDir)
 	}
-	ctx = ctx.WithEnabledColor(r.enabledColor)
+	ctx = ctx.WithEnabledColor(r.enabledColor).WithDryRun(r.isDryRun)
+
 	for _, f := range r.scenarioFiles {
 		ctx.Run(f, func(ctx *context.Context) {
 			scns, err := schema.LoadScenarios(f)

--- a/runner_test.go
+++ b/runner_test.go
@@ -9,9 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/zoncoen/scenarigo/assert"
 	"github.com/zoncoen/scenarigo/context"
-	"github.com/zoncoen/scenarigo/protocol"
 	"github.com/zoncoen/scenarigo/reporter"
 )
 
@@ -31,53 +29,9 @@ func TestRunnerWithScenarios(t *testing.T) {
 	}
 }
 
-type testProtocol struct {
-	name    string
-	invoker invoker
-	builder builder
-}
-
-func (p *testProtocol) Name() string { return p.name }
-
-func (p *testProtocol) UnmarshalRequest(_ []byte) (protocol.Invoker, error) {
-	return p.invoker, nil
-}
-
-func (p *testProtocol) UnmarshalExpect(_ []byte) (protocol.AssertionBuilder, error) {
-	return p.builder, nil
-}
-
-type invoker func(*context.Context) (*context.Context, interface{}, error)
-
-func (f invoker) Invoke(ctx *context.Context) (*context.Context, interface{}, error) {
-	return f(ctx)
-}
-
-type builder func(*context.Context) (assert.Assertion, error)
-
-func (f builder) Build(ctx *context.Context) (assert.Assertion, error) {
-	return f(ctx)
-}
-
 func TestRunnerWithDryRun(t *testing.T) {
-	scenariosPath := filepath.Join("test", "e2e", "testdata", "scenarios")
-	pluginPath := filepath.Join("test", "e2e", "testdata", "gen", "plugins")
-
-	p := &testProtocol{
-		name: "test",
-		invoker: invoker(func(ctx *context.Context) (*context.Context, interface{}, error) {
-			return ctx, nil, nil
-		}),
-		builder: builder(func(ctx *context.Context) (assert.Assertion, error) {
-			return assert.AssertionFunc(func(_ interface{}) error { return nil }), nil
-		}),
-	}
-	protocol.Register(p)
-	defer protocol.Unregister(p.Name())
-
 	runner, err := NewRunner(
-		WithScenarios(scenariosPath),
-		WithPluginDir(pluginPath),
+		WithScenarios("testdata"),
 		WithDryRun(true),
 	)
 	if err != nil {

--- a/step.go
+++ b/step.go
@@ -51,7 +51,7 @@ func runStep(ctx *context.Context, s *schema.Step, stepIdx int) *context.Context
 		ctx = ctx.WithNode(currentNode)
 		return ctx
 	}
-	if s.Ref != "" {
+	if s.Ref != "" && !ctx.DryRun() {
 		x, err := ctx.ExecuteTemplate(s.Ref)
 		if err != nil {
 			ctx.Reporter().Fatal(

--- a/step.go
+++ b/step.go
@@ -87,6 +87,10 @@ func runStep(ctx *context.Context, s *schema.Step, stepIdx int) *context.Context
 }
 
 func invokeAndAssert(ctx *context.Context, s *schema.Step, stepIdx int) *context.Context {
+	if ctx.DryRun() {
+		return ctx
+	}
+
 	policy, err := s.Retry.Build()
 	if err != nil {
 		ctx.Reporter().Fatal(xerrors.Errorf("invalid retry policy: %w", err))


### PR DESCRIPTION
If `--dry-run` option is enabled , `scenarigo` run without request invoking and assertion .

And I add a new member `captureCtx` to `context.Context` structure, it aims to use variables shared all contexts .
As example, I add a member ( `subtests` ) to this for saving names of subtest .
