### PR TITLE
Add list as sub command

### DIFF
--- a/cmd/scenarigo/cmd/list.go
+++ b/cmd/scenarigo/cmd/list.go
@@ -13,7 +13,7 @@ import (
 
 var listCmd = &cobra.Command{
 	Use:           "list",
-	Short:         "list test scenarios",
+	Short:         "lists the test scenarios ( or steps of scenario )",
 	Args:          cobra.MinimumNArgs(1),
 	RunE:          list,
 	SilenceErrors: true,

--- a/cmd/scenarigo/cmd/list.go
+++ b/cmd/scenarigo/cmd/list.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+	"github.com/zoncoen/scenarigo"
+	"github.com/zoncoen/scenarigo/context"
+	"github.com/zoncoen/scenarigo/reporter"
+)
+
+var listCmd = &cobra.Command{
+	Use:           "list",
+	Short:         "list test scenarios",
+	Args:          cobra.MinimumNArgs(1),
+	RunE:          list,
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+var (
+	verboseList bool
+	fileList    bool
+)
+
+func init() {
+	listCmd.Flags().BoolVarP(&verboseList, "verbose", "v", false, "show steps of scenario")
+	listCmd.Flags().BoolVarP(&fileList, "file", "f", false, "show file names only")
+	rootCmd.AddCommand(listCmd)
+}
+
+func sortedScenarioNames(scenarioMap map[string][]string) []string {
+	scenarioNames := []string{}
+	for scenarioName := range scenarioMap {
+		scenarioNames = append(scenarioNames, scenarioName)
+	}
+	sort.Strings(scenarioNames)
+	return scenarioNames
+}
+
+func list(cmd *cobra.Command, args []string) error {
+	opts := []func(*scenarigo.Runner) error{}
+	for _, arg := range args {
+		opts = append(opts, scenarigo.WithScenarios(arg))
+	}
+	r, err := scenarigo.NewRunner(opts...)
+	if err != nil {
+		return err
+	}
+
+	var b bytes.Buffer
+	reporterOpts := []reporter.Option{reporter.WithWriter(&b)}
+	reporter.Run(func(rptr reporter.Reporter) {
+		for _, file := range r.ScenarioFiles() {
+			scenarioMap, err := r.ScenarioMap(context.New(rptr), file)
+			if err != nil {
+				continue
+			}
+			if fileList {
+				fmt.Println(file)
+				continue
+			}
+			for _, name := range sortedScenarioNames(scenarioMap) {
+				fmt.Println(name)
+				if !verboseList {
+					continue
+				}
+				for _, step := range scenarioMap[name] {
+					fmt.Println(step)
+				}
+			}
+		}
+	}, reporterOpts...)
+	return nil
+}

--- a/cmd/scenarigo/cmd/list_test.go
+++ b/cmd/scenarigo/cmd/list_test.go
@@ -1,0 +1,10 @@
+package cmd
+
+import "testing"
+
+func TestList(t *testing.T) {
+	verboseList = true
+	if err := list(nil, []string{"testdata"}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/runner_test.go
+++ b/runner_test.go
@@ -136,3 +136,35 @@ func TestRunnerFail(t *testing.T) {
 		}
 	}
 }
+
+func TestRunner_ScenarioFiles(t *testing.T) {
+	scenariosPath := filepath.Join("test", "e2e", "testdata", "scenarios")
+	runner, err := NewRunner(WithScenarios(scenariosPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.ScenarioFiles()) == 0 {
+		t.Fatal("failed to get scenario files")
+	}
+}
+
+func TestRunner_ScenarioMap(t *testing.T) {
+	runner, err := NewRunner(WithScenarios("testdata"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range runner.ScenarioFiles() {
+		m, err := runner.ScenarioMap(context.FromT(t), file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(m) == 0 {
+			t.Fatal("failed to get scenarios")
+		}
+		for _, steps := range m {
+			if len(steps) == 0 {
+				t.Fatal("failed to get steps from scenario map")
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Usage

```
$ scenarigo list --help
```

```
lists the test scenarios ( or steps of scenario )

Usage:
  scenarigo list [flags]

Flags:
  -f, --file      show file names only
  -h, --help      help for list
  -v, --verbose   show steps of scenario
```

## Example

The following are working under the `scenarigo` directory .

### `scenarigo list /path/to/scenario`

```
$ scenarigo list ./testdata
```

```
testdata/base.yaml//echo
testdata/base_error.yaml//echo
testdata/use_include.yaml//echo
testdata/use_include_error.yaml//echo
```

### `scenarigo list -v /path/to/scenario`

```
$ scenarigo list -v ./testdata
```

```
testdata/base.yaml//echo
testdata/base.yaml//echo/POST_/echo
testdata/base_error.yaml//echo
testdata/base_error.yaml//echo/POST_/echo
testdata/use_include.yaml//echo
testdata/use_include.yaml//echo/POST_/echo_by_include
testdata/use_include_error.yaml//echo
testdata/use_include_error.yaml//echo/POST_/echo_by_include
```

### `scenarigo list --file ./testdata`

```
testdata/base.yaml
testdata/base_error.yaml
testdata/use_include.yaml
testdata/use_include_error.yaml
```