### PR TITLE
Improve log format

### DIFF
--- a/protocol/grpc/request.go
+++ b/protocol/grpc/request.go
@@ -2,7 +2,9 @@ package grpc
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/goccy/go-yaml"
 	"github.com/golang/protobuf/jsonpb"
@@ -29,6 +31,19 @@ type response struct {
 	Trailer metadata.MD     `yaml:"trailer,omitempty"`
 	Body    interface{}     `yaml:"body,omitempty"`
 	rvalues []reflect.Value `yaml:"-"`
+}
+
+const (
+	indentNum = 2
+)
+
+func (r *Request) addIndent(s string, indentNum int) string {
+	indent := strings.Repeat(" ", indentNum)
+	lines := []string{}
+	for _, line := range strings.Split(s, "\n") {
+		lines = append(lines, fmt.Sprintf("%s%s", indent, line))
+	}
+	return strings.Join(lines, "\n")
 }
 
 // Invoke implements protocol.Invoker interface.
@@ -104,7 +119,7 @@ func (r *Request) Invoke(ctx *context.Context) (*context.Context, interface{}, e
 				Metadata: reqMD,
 				Body:     req,
 			}); err == nil {
-				ctx.Reporter().Logf("request:\n%s", string(b))
+				ctx.Reporter().Logf("request:\n%s", r.addIndent(string(b), indentNum))
 			} else {
 				ctx.Reporter().Logf("failed to dump request:\n%s", err)
 			}
@@ -129,7 +144,7 @@ func (r *Request) Invoke(ctx *context.Context) (*context.Context, interface{}, e
 	}
 	ctx = ctx.WithResponse(body)
 	if b, err := yaml.Marshal(resp); err == nil {
-		ctx.Reporter().Logf("response:\n%s", string(b))
+		ctx.Reporter().Logf("response:\n%s", r.addIndent(string(b), indentNum))
 	} else {
 		ctx.Reporter().Logf("failed to dump response:\n%s", err)
 	}

--- a/protocol/grpc/request_test.go
+++ b/protocol/grpc/request_test.go
@@ -214,17 +214,19 @@ func TestRequest_Invoke_Log(t *testing.T) {
 === RUN   test.yaml
 --- PASS: test.yaml (0.00s)
         request:
-        method: Echo
-        metadata:
-          version:
-          - 1.0.0
-        body:
-          messageId: "1"
-          messageBody: hello
+          method: Echo
+          metadata:
+            version:
+            - 1.0.0
+          body:
+            messageId: "1"
+            messageBody: hello
+          
         response:
-        body:
-          messageId: "1"
-          messageBody: hello
+          body:
+            messageId: "1"
+            messageBody: hello
+          
 PASS
 ok  	test.yaml	0.000s
 `

--- a/protocol/grpc/request_test.go
+++ b/protocol/grpc/request_test.go
@@ -213,7 +213,7 @@ func TestRequest_Invoke_Log(t *testing.T) {
 	expect := `
 === RUN   test.yaml
 --- PASS: test.yaml (0.00s)
-    request:
+        request:
         method: Echo
         metadata:
           version:
@@ -221,7 +221,7 @@ func TestRequest_Invoke_Log(t *testing.T) {
         body:
           messageId: "1"
           messageBody: hello
-    response:
+        response:
         body:
           messageId: "1"
           messageBody: hello

--- a/protocol/http/request.go
+++ b/protocol/http/request.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 
 	"github.com/goccy/go-yaml"
 	"github.com/zoncoen/scenarigo/context"
@@ -37,6 +38,19 @@ type response struct {
 	status string              `yaml:"-"` // http.Response.Status format e.g. "200 OK"
 }
 
+const (
+	indentNum = 2
+)
+
+func (r *Request) addIndent(s string, indentNum int) string {
+	indent := strings.Repeat(" ", indentNum)
+	lines := []string{}
+	for _, line := range strings.Split(s, "\n") {
+		lines = append(lines, fmt.Sprintf("%s%s", indent, line))
+	}
+	return strings.Join(lines, "\n")
+}
+
 // Invoke implements protocol.Invoker interface.
 func (r *Request) Invoke(ctx *context.Context) (*context.Context, interface{}, error) {
 	client, err := r.buildClient(ctx)
@@ -55,7 +69,7 @@ func (r *Request) Invoke(ctx *context.Context) (*context.Context, interface{}, e
 		Header: req.Header,
 		Body:   reqBody,
 	}); err == nil {
-		ctx.Reporter().Logf("request:\n%s", string(b))
+		ctx.Reporter().Logf("request:\n%s", r.addIndent(string(b), indentNum))
 	} else {
 		ctx.Reporter().Logf("failed to dump request:\n%s", err)
 	}
@@ -97,7 +111,7 @@ func (r *Request) Invoke(ctx *context.Context) (*context.Context, interface{}, e
 		rvalue.Body = respBody
 		ctx = ctx.WithResponse(respBody)
 		if b, err := yaml.Marshal(rvalue); err == nil {
-			ctx.Reporter().Logf("response:\n%s", string(b))
+			ctx.Reporter().Logf("response:\n%s", r.addIndent(string(b), indentNum))
 		} else {
 			ctx.Reporter().Logf("failed to dump response:\n%s", err)
 		}

--- a/protocol/http/request_test.go
+++ b/protocol/http/request_test.go
@@ -304,7 +304,7 @@ func TestRequest_Invoke_Log(t *testing.T) {
 		expect := fmt.Sprintf(`
 === RUN   test.yaml
 --- PASS: test.yaml (0.00s)
-    request:
+        request:
         method: POST
         url: %s/echo?query=hello
         header:
@@ -312,7 +312,7 @@ func TestRequest_Invoke_Log(t *testing.T) {
           - %s
         body:
           message: hey
-    response:
+        response:
         header:
           Content-Length:
           - "18"

--- a/protocol/http/request_test.go
+++ b/protocol/http/request_test.go
@@ -305,21 +305,23 @@ func TestRequest_Invoke_Log(t *testing.T) {
 === RUN   test.yaml
 --- PASS: test.yaml (0.00s)
         request:
-        method: POST
-        url: %s/echo?query=hello
-        header:
-          User-Agent:
-          - %s
-        body:
-          message: hey
+          method: POST
+          url: %s/echo?query=hello
+          header:
+            User-Agent:
+            - %s
+          body:
+            message: hey
+          
         response:
-        header:
-          Content-Length:
-          - "18"
-          Content-Type:
-          - application/json
-        body:
-          message: hey
+          header:
+            Content-Length:
+            - "18"
+            Content-Type:
+            - application/json
+          body:
+            message: hey
+          
 PASS
 ok  	test.yaml	0.000s
 `, srv.URL, defaultUserAgent)

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -357,10 +357,13 @@ func collectOutput(r *reporter) []string {
 
 func pad(s string, padding string) string {
 	s = strings.Trim(s, "\n")
+	indent := strings.Repeat(" ", 4)
 	var b strings.Builder
 	for i, l := range strings.Split(s, "\n") {
-		if i != 0 {
-			b.WriteString("\n    ")
+		if i == 0 {
+			b.WriteString(indent)
+		} else {
+			b.WriteString("\n" + indent)
 		}
 		b.WriteString(padding)
 		b.WriteString(l)

--- a/reporter/reporter_test.go
+++ b/reporter/reporter_test.go
@@ -329,7 +329,7 @@ ok  	a	1.234s
 			},
 			expect: `
 --- FAIL: a (1.23s)
-    error!
+        error!
 FAIL
 FAIL	a	1.234s
 FAIL
@@ -365,7 +365,7 @@ ok  	a	0.000s
 --- FAIL: a (0.00s)
     --- FAIL: a/b (0.00s)
         --- FAIL: a/b/c (1.23s)
-            error!
+                error!
 FAIL
 FAIL	a	0.000s
 FAIL
@@ -389,7 +389,7 @@ FAIL
 --- PASS: a (0.00s)
     --- PASS: a/b (0.00s)
         --- PASS: a/b/c (0.00s)
-            ok!
+                ok!
 PASS
 ok  	a	0.000s
 `,
@@ -414,7 +414,7 @@ ok  	a	0.000s
 --- FAIL: a (0.00s)
     --- FAIL: a/b (0.00s)
         --- FAIL: a/b/c (1.23s)
-            error!
+                error!
 FAIL
 FAIL	a	0.000s
 FAIL
@@ -436,7 +436,7 @@ FAIL
 --- FAIL: a (0.00s)
     --- FAIL: a/b (0.00s)
         --- FAIL: a/b/c (0.00s)
-            1
+                1
                 2
                 3
 FAIL

--- a/reporter/testing.go
+++ b/reporter/testing.go
@@ -3,21 +3,26 @@ package reporter
 import (
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"unsafe"
 )
 
 // FromT creates Reporter from t.
 func FromT(t *testing.T) Reporter {
-	return &testReporter{t}
+	return &testReporter{T: t}
 }
 
 // testReporter is a wrapper to provide Reporter interface for *testing.T.
 type testReporter struct {
 	*testing.T
+	mu sync.Mutex
 }
 
 func (r *testReporter) addBufferDirectly(b []byte) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	t := reflect.ValueOf(r.T).Elem()
 	common := t.FieldByName("common")
 	if !common.IsValid() {

--- a/reporter/testing_test.go
+++ b/reporter/testing_test.go
@@ -5,3 +5,12 @@ import "testing"
 func TestFromT(t *testing.T) {
 	var _ Reporter = FromT(t)
 }
+
+func Test_TestingLog(t *testing.T) {
+	rptr := FromT(t)
+	rptr.Log("log test")
+	rptr.Run("subtest", func(rptr Reporter) {
+		rptr.Logf("%s", "log test")
+		rptr.Skip()
+	})
+}


### PR DESCRIPTION
### 1 
- Need to indent for first line of log ( https://github.com/zoncoen/scenarigo/compare/master...goccy:feature/fix-log-format?expand=1#diff-366f112cf4c3ced1e7a80a3a4fdd325fR364 )
  - FYI: https://github.com/golang/go/blob/master/src/testing/testing.go#L520-L557 

### 2 
In order to solve the problem that unnecessary file name and number of lines were displayed when using testing.T,
write log directly to the buffer held by `testing.T` .
If this process failed, it falls back to the regular API.

FYI: https://github.com/golang/go/blob/master/src/testing/testing.go#L388