### PR TITLE
Use the default AssertionBuilder of a protocol if expect is empty

### DIFF
--- a/protocol/grpc/expect_test.go
+++ b/protocol/grpc/expect_test.go
@@ -247,6 +247,16 @@ func TestExpect_Build(t *testing.T) {
 				},
 				expectAssertError: true,
 			},
+			"wrong code in case of default": {
+				expect: &Expect{},
+				v: response{
+					rvalues: []reflect.Value{
+						reflect.Zero(reflect.TypeOf(&test.EchoResponse{})),
+						reflect.ValueOf(status.New(codes.InvalidArgument, "invalid argument").Err()),
+					},
+				},
+				expectAssertError: true,
+			},
 			"wrong code": {
 				expect: &Expect{
 					Code: "OK",

--- a/protocol/grpc/grpc.go
+++ b/protocol/grpc/grpc.go
@@ -31,6 +31,9 @@ func (p *GRPC) UnmarshalRequest(b []byte) (protocol.Invoker, error) {
 // UnmarshalExpect implements protocol.Protocol interface.
 func (p *GRPC) UnmarshalExpect(b []byte) (protocol.AssertionBuilder, error) {
 	var e Expect
+	if b == nil {
+		return &e, nil
+	}
 	if err := yaml.NewDecoder(bytes.NewBuffer(b), yaml.UseOrderedMap()).Decode(&e); err != nil {
 		return nil, err
 	}

--- a/protocol/grpc/grpc_test.go
+++ b/protocol/grpc/grpc_test.go
@@ -1,0 +1,40 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGRPC_UnmarshalExpect(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		tests := map[string]struct {
+			bytes  []byte
+			expect *Expect
+		}{
+			"default": {
+				bytes:  nil,
+				expect: &Expect{},
+			},
+			"code": {
+				bytes: []byte(`code: InvalidArgument`),
+				expect: &Expect{
+					Code: "InvalidArgument",
+				},
+			},
+		}
+		for name, test := range tests {
+			test := test
+			t.Run(name, func(t *testing.T) {
+				p := &GRPC{}
+				builder, err := p.UnmarshalExpect(test.bytes)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				if diff := cmp.Diff(test.expect, builder); diff != "" {
+					t.Errorf("request differs (-want +got):\n%s", diff)
+				}
+			})
+		}
+	})
+}

--- a/protocol/http/http.go
+++ b/protocol/http/http.go
@@ -31,6 +31,9 @@ func (p *HTTP) UnmarshalRequest(b []byte) (protocol.Invoker, error) {
 // UnmarshalExpect implements protocol.Protocol interface.
 func (p *HTTP) UnmarshalExpect(b []byte) (protocol.AssertionBuilder, error) {
 	var e Expect
+	if b == nil {
+		return &e, nil
+	}
 	if err := yaml.NewDecoder(bytes.NewBuffer(b), yaml.UseOrderedMap()).Decode(&e); err != nil {
 		return nil, err
 	}

--- a/protocol/http/http_test.go
+++ b/protocol/http/http_test.go
@@ -1,0 +1,40 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestHTTP_UnmarshalExpect(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		tests := map[string]struct {
+			bytes  []byte
+			expect *Expect
+		}{
+			"default": {
+				bytes:  nil,
+				expect: &Expect{},
+			},
+			"code": {
+				bytes: []byte(`code: 404`),
+				expect: &Expect{
+					Code: "404",
+				},
+			},
+		}
+		for name, test := range tests {
+			test := test
+			t.Run(name, func(t *testing.T) {
+				p := &HTTP{}
+				builder, err := p.UnmarshalExpect(test.bytes)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				if diff := cmp.Diff(test.expect, builder); diff != "" {
+					t.Errorf("request differs (-want +got):\n%s", diff)
+				}
+			})
+		}
+	})
+}

--- a/schema/load_test.go
+++ b/schema/load_test.go
@@ -26,6 +26,9 @@ func (p *testProtocol) UnmarshalRequest(b []byte) (protocol.Invoker, error) {
 }
 
 func (p *testProtocol) UnmarshalExpect(b []byte) (protocol.AssertionBuilder, error) {
+	if b == nil {
+		return &testAssertionBuilder{}, nil
+	}
 	if err := yaml.NewDecoder(bytes.NewBuffer(b), yaml.UseOrderedMap()).Decode(&p.expect); err != nil {
 		return nil, err
 	}
@@ -141,6 +144,36 @@ func TestLoadScenarios(t *testing.T) {
 				},
 				request: map[interface{}]interface{}{},
 				expect:  map[interface{}]interface{}{},
+			},
+			"without expect": {
+				path: "testdata/valid-without-expect.yaml",
+
+				scenarios: []*Scenario{
+					{
+						Title:       "echo-service",
+						Description: "check echo-service",
+						Vars:        map[string]interface{}{"message": "hello"},
+						Steps: []*Step{
+							{
+								Title:       "POST /say",
+								Description: "check to respond same message",
+								Vars:        nil,
+								Protocol:    "test",
+								Expect: Expect{
+									AssertionBuilder: &testAssertionBuilder{},
+									bytes:            nil,
+								},
+							},
+						},
+						filepath: "testdata/valid-without-expect.yaml",
+					},
+				},
+				request: map[string]interface{}{
+					"body": map[string]interface{}{
+						"message": "{{vars.message}}",
+					},
+				},
+				expect: map[interface{}]interface{}{},
 			},
 		}
 		for name, test := range tests {

--- a/schema/load_test.go
+++ b/schema/load_test.go
@@ -109,6 +109,25 @@ func TestLoadScenarios(t *testing.T) {
 					},
 				},
 			},
+			"without protocol": {
+				path: "testdata/valid-without-protocol.yaml",
+
+				scenarios: []*Scenario{
+					{
+						Title:       "echo-service",
+						Description: "check echo-service",
+						Vars:        map[string]interface{}{"message": "hello"},
+						Steps: []*Step{
+							{
+								Include: "./valid.yaml",
+							},
+						},
+						filepath: "testdata/valid-without-protocol.yaml",
+					},
+				},
+				request: map[interface{}]interface{}{},
+				expect:  map[interface{}]interface{}{},
+			},
 		}
 		for name, test := range tests {
 			test := test

--- a/schema/scenario.go
+++ b/schema/scenario.go
@@ -65,13 +65,11 @@ func (s *Step) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 		s.Request.Invoker = invoker
 	}
-	if s.Expect.bytes != nil {
-		builder, err := p.UnmarshalExpect(s.Expect.bytes)
-		if err != nil {
-			return err
-		}
-		s.Expect.AssertionBuilder = builder
+	builder, err := p.UnmarshalExpect(s.Expect.bytes)
+	if err != nil {
+		return err
 	}
+	s.Expect.AssertionBuilder = builder
 
 	return nil
 }

--- a/schema/scenario.go
+++ b/schema/scenario.go
@@ -56,6 +56,7 @@ func (s *Step) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if s.Request.bytes != nil || s.Expect.bytes != nil {
 			return errors.Errorf("unknown protocol: %s", s.Protocol)
 		}
+		return nil
 	}
 	if s.Request.bytes != nil {
 		invoker, err := p.UnmarshalRequest(s.Request.bytes)

--- a/schema/testdata/valid-without-expect.yaml
+++ b/schema/testdata/valid-without-expect.yaml
@@ -1,0 +1,11 @@
+title: echo-service
+description: check echo-service
+vars:
+  message: hello
+steps:
+  - title: POST /say
+    description: check to respond same message
+    protocol: test
+    request:
+      body:
+        message: "{{vars.message}}"

--- a/schema/testdata/valid-without-protocol.yaml
+++ b/schema/testdata/valid-without-protocol.yaml
@@ -1,0 +1,6 @@
+title: echo-service
+description: check echo-service
+vars:
+  message: hello
+steps:
+  - include: ./valid.yaml


### PR DESCRIPTION
# What
This PR modifies the unmarshaling process to set the default `AssertionBuilder` of a protocol to `Step` in case `expect` is empty, instead of skipping assertion. `UnmarshalExpect` of `http` and `grpc` is modified to return a default `AssertionBuilder` if the given bytes is nil. 

The default `AssertionBuilder`s i.e. `Expect`s of them are left as is, and only a few test cases to check its default behavior are added.

# Why
`http` and `grpc` checks the status code of the response is `OK` if the `expect.code` is empty but `expect.body` is not. However, if `expect` is empty, the assertion does not run at all because scenarigo sets nil to the `Expect.AssertionBuilder` of the step. It makes more sense to allow protocols to decide what to test by default in such case.
