### PR TITLE
fix: register errdetails proto messages to unmarshal Any

### DIFF
--- a/protocol/grpc/expect.go
+++ b/protocol/grpc/expect.go
@@ -9,6 +9,9 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	// Register proto messages to unmarshal com.google.protobuf.Any.
+	_ "google.golang.org/genproto/googleapis/rpc/errdetails"
+
 	"github.com/goccy/go-yaml"
 	"github.com/golang/protobuf/proto"
 	"github.com/zoncoen/scenarigo/assert"


### PR DESCRIPTION
Import `errdetails` package to register the proto messages (e.g.: `BadReqest`, `PreconditionFailure`, etc.). If they're not registered, it fails to decode `Any` message into a concrete type struct.