### PR TITLE
Add binaryUnmarshaler and use it as the default http response unmarshaler

### DIFF
--- a/protocol/http/unmarshaler/binary.go
+++ b/protocol/http/unmarshaler/binary.go
@@ -1,0 +1,39 @@
+package unmarshaler
+
+import (
+	"errors"
+	"reflect"
+)
+
+func init() {
+	if err := Register(&binaryUnmarshaler{}); err != nil {
+		panic(err)
+	}
+}
+
+type binaryUnmarshaler struct{}
+
+// MediaType implements ResponseUnmarshaler interface.
+// It returns a wildcard type to denote that binaryUnmarshaler is the fallback unmarshaler
+// used for responses that do not mach a registered media type.
+func (um *binaryUnmarshaler) MediaType() string {
+	return "*/*"
+}
+
+// Unmarshal implements ResponseUnmarshaler interface.
+// It unmarshals the data as just a sequence of bytes.
+func (um *binaryUnmarshaler) Unmarshal(data []byte, v interface{}) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr {
+		return errors.New("v must be a pointer")
+	}
+	if rv.IsNil() {
+		return errors.New("v is nil")
+	}
+	rv = rv.Elem()
+	if !rv.CanSet() {
+		return errors.New("v is not settable")
+	}
+	rv.Set(reflect.ValueOf(data))
+	return nil
+}

--- a/protocol/http/unmarshaler/binary_test.go
+++ b/protocol/http/unmarshaler/binary_test.go
@@ -1,0 +1,18 @@
+package unmarshaler
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBinaryUnmarshaler_Unmarshal(t *testing.T) {
+	var um binaryUnmarshaler
+	var i interface{}
+	d := []byte("test")
+	if err := um.Unmarshal(d, &i); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(d, i) {
+		t.Errorf(`expected "%#v" but got "%#v"`, d, i)
+	}
+}

--- a/protocol/http/unmarshaler/unmarshaler.go
+++ b/protocol/http/unmarshaler/unmarshaler.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Default is the default response unmarshaler.
-var Default = &jsonUnmarshaler{}
+var Default = &binaryUnmarshaler{}
 
 var (
 	resm        sync.Mutex

--- a/protocol/http/unmarshaler/unmarshaler_test.go
+++ b/protocol/http/unmarshaler/unmarshaler_test.go
@@ -1,0 +1,13 @@
+package unmarshaler
+
+import "testing"
+
+func TestGet(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		um := Get("image/jpeg")
+		_, ok := um.(*binaryUnmarshaler)
+		if !ok {
+			t.Errorf("expected *binaryUnmarshaler but got %T", um)
+		}
+	})
+}

--- a/test/e2e/testdata/scenarios/assert.yaml
+++ b/test/e2e/testdata/scenarios/assert.yaml
@@ -5,6 +5,8 @@ steps:
   request:
     method: GET
     url: '{{env.TEST_ADDR}}'
+    header:
+      content-type: application/json
     body:
       message: 'hello'
   expect:
@@ -19,6 +21,8 @@ steps:
   request:
     method: GET
     url: '{{env.TEST_ADDR}}'
+    header:
+      content-type: application/json
     body:
       users:
         - id: 1

--- a/testdata/base.yaml
+++ b/testdata/base.yaml
@@ -11,6 +11,8 @@ steps:
   request:
     method: POST
     url: "{{env.TEST_ADDR}}/echo"
+    header:
+      content-type: application/json
     body:
       message: "{{vars.message}}"
   expect:

--- a/testdata/use_include.yaml
+++ b/testdata/use_include.yaml
@@ -3,14 +3,3 @@ title: /echo
 steps:
 - title: POST /echo by include
   include: base.yaml
-  protocol: http
-  request:
-    method: POST
-    url: "{{env.TEST_ADDR}}/echo"
-    body:
-      message: "{{vars.message}}"
-  expect:
-    code: 200
-    body:
-      message: "{{request.message}}"
-

--- a/testdata/use_include_error.yaml
+++ b/testdata/use_include_error.yaml
@@ -3,14 +3,3 @@ title: /echo
 steps:
 - title: POST /echo by include
   include: base_error.yaml
-  protocol: http
-  request:
-    method: POST
-    url: "{{env.TEST_ADDR}}/echo"
-    body:
-      message: "{{vars.message}}"
-  expect:
-    code: 200
-    body:
-      message: "{{request.message}}"
-


### PR DESCRIPTION
Add binaryUnmarshaler that unmarshals response data as just a sequence of bytes, and use it as the default HTTP response unmarshaler.
This PR changes the default behavior but it makes more sense not to expect a certain data format when you don't know how to handle the given media type. You can also add a custom unmarshaler if necessary.