### PR TITLE
Enable strict option when decoding yaml for expect to prevent field misplacement

### DIFF
--- a/protocol/grpc/grpc.go
+++ b/protocol/grpc/grpc.go
@@ -34,7 +34,8 @@ func (p *GRPC) UnmarshalExpect(b []byte) (protocol.AssertionBuilder, error) {
 	if b == nil {
 		return &e, nil
 	}
-	if err := yaml.NewDecoder(bytes.NewBuffer(b), yaml.UseOrderedMap()).Decode(&e); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewBuffer(b), yaml.UseOrderedMap(), yaml.Strict())
+	if err := decoder.Decode(&e); err != nil {
 		return nil, err
 	}
 	return &e, nil

--- a/protocol/grpc/grpc_test.go
+++ b/protocol/grpc/grpc_test.go
@@ -37,4 +37,27 @@ func TestGRPC_UnmarshalExpect(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("ng", func(t *testing.T) {
+		tests := map[string]struct {
+			bytes []byte
+		}{
+			"unknown field": {
+				bytes: []byte(`a: b`),
+			},
+			"duplicated field": {
+				bytes: []byte("code: InvalidArgument\ncode: InvalidArgument"),
+			},
+		}
+		for name, test := range tests {
+			test := test
+			t.Run(name, func(t *testing.T) {
+				p := &GRPC{}
+				_, err := p.UnmarshalExpect(test.bytes)
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+			})
+		}
+	})
 }

--- a/protocol/http/http.go
+++ b/protocol/http/http.go
@@ -34,7 +34,8 @@ func (p *HTTP) UnmarshalExpect(b []byte) (protocol.AssertionBuilder, error) {
 	if b == nil {
 		return &e, nil
 	}
-	if err := yaml.NewDecoder(bytes.NewBuffer(b), yaml.UseOrderedMap()).Decode(&e); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewBuffer(b), yaml.UseOrderedMap(), yaml.Strict())
+	if err := decoder.Decode(&e); err != nil {
 		return nil, err
 	}
 	return &e, nil

--- a/protocol/http/http_test.go
+++ b/protocol/http/http_test.go
@@ -37,4 +37,27 @@ func TestHTTP_UnmarshalExpect(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("ng", func(t *testing.T) {
+		tests := map[string]struct {
+			bytes []byte
+		}{
+			"unknown field": {
+				bytes: []byte(`a: b`),
+			},
+			"duplicated field": {
+				bytes: []byte("code: 404\ncode: 404"),
+			},
+		}
+		for name, test := range tests {
+			test := test
+			t.Run(name, func(t *testing.T) {
+				p := &HTTP{}
+				_, err := p.UnmarshalExpect(test.bytes)
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
Enable strict option when decoding yaml for expect to prevent tests falsely pass when fields are misplaced.

This patch prevents expect fields like the following: 

```
protocol: grpc
...
expect:
  details:
    - google.rpc.LocalizedMessage:
        locale: ja-JP
        message: message
```

This test passes regardless of `response.status.details` because `details` is placed directly under `expect`, not under `expect.status`. With this PR, the test fails when decoding the above yaml, preventing the test from falsely passing.