### PR TITLE
allow assertion for header value

### DIFF
--- a/protocol/http/expect.go
+++ b/protocol/http/expect.go
@@ -7,7 +7,6 @@ import (
 	"github.com/zoncoen/scenarigo/assert"
 	"github.com/zoncoen/scenarigo/context"
 	"github.com/zoncoen/scenarigo/errors"
-	"github.com/zoncoen/scenarigo/internal/maputil"
 )
 
 // Expect represents expected response values.
@@ -29,6 +28,12 @@ func (e *Expect) Build(ctx *context.Context) (assert.Assertion, error) {
 	}
 	codeAssertion := assert.Build(executedCode)
 
+	expectHeader, err := ctx.ExecuteTemplate(e.Header)
+	if err != nil {
+		return nil, errors.WrapPathf(err, "header", "invalid expect header response")
+	}
+	headerAssertion := assert.Build(expectHeader)
+
 	expectBody, err := ctx.ExecuteTemplate(e.Body)
 	if err != nil {
 		return nil, errors.WrapPathf(err, "body", "invalid expect response")
@@ -43,7 +48,7 @@ func (e *Expect) Build(ctx *context.Context) (assert.Assertion, error) {
 		if err := assertCode(codeAssertion, res.status); err != nil {
 			return errors.WithPath(err, "code")
 		}
-		if err := e.assertHeader(res.Header); err != nil {
+		if err := headerAssertion.Assert(res.Header); err != nil {
 			return errors.WithPath(err, "header")
 		}
 		if err := assertion.Assert(res.Body); err != nil {
@@ -51,20 +56,6 @@ func (e *Expect) Build(ctx *context.Context) (assert.Assertion, error) {
 		}
 		return nil
 	}), nil
-}
-
-func (e *Expect) assertHeader(header map[string][]string) error {
-	if len(e.Header) == 0 {
-		return nil
-	}
-	headerMap, err := maputil.ConvertStringsMapSlice(e.Header)
-	if err != nil {
-		return err
-	}
-	if err := assert.Build(headerMap).Assert(header); err != nil {
-		return err
-	}
-	return nil
 }
 
 func assertCode(assertion assert.Assertion, status string) error {

--- a/protocol/http/expect_test.go
+++ b/protocol/http/expect_test.go
@@ -48,8 +48,10 @@ func TestExpect_Build(t *testing.T) {
 				expect: &Expect{
 					Header: yaml.MapSlice{
 						{
-							Key:   "Content-Type",
-							Value: "application/json",
+							Key: "Content-Type",
+							Value: []string{
+								"application/json",
+							},
 						},
 					},
 				},

--- a/test/e2e/testdata/scenarios/http.yaml
+++ b/test/e2e/testdata/scenarios/http.yaml
@@ -27,7 +27,8 @@ steps:
   expect:
     code: 200
     header:
-      Content-Length: 36
+      Content-Length:
+      - "36"
     body:
       id: "{{vars.id}}"
       message: "{{request.message}}"
@@ -52,7 +53,8 @@ steps:
     code: 200
     body: "123, hello, true"
     header:
-      Content-Type: 'text/plain; charset=utf-8'
+      Content-Type:
+      - "text/plain; charset=utf-8"
 
 ---
 title: not found
@@ -66,7 +68,7 @@ steps:
     code: Not Found
     header:
       Content-Length:
-        - 0
+      - "0"
 
 ---
 title: forbidden
@@ -109,7 +111,8 @@ steps:
     expect:
       code: 200
       header:
-        Content-Length: 38
+        Content-Length:
+        - "38"
       body:
         message: |-
           line1


### PR DESCRIPTION
# What

allow assertion for header value

# Why 
scenarigo doesn't allow to assert for Header value because assertion function like `{{assert.NotZero}}` is judged by string . so we cannot use the assert function to assert header value.

```
53 |     body: "123, hello, true"
54 |     header:
> 55 |       Content-Type: "{{assert.notZero}}"
^
57 | ---
58 | title: not found
59 |
.Content-Type: expected [{{assert.notZero}}] but got [text/plain; charset=utf-8]
```

# PR's Breaking Change

- Cannot use number for header validation:
ex: https://github.com/zoncoen/scenarigo/pull/66/files#diff-5f1933881375b4c4729501a49ff3b1237f39204e6c3dedcb92884bee72520978L69

- Cannot use yaml string format
ex: https://github.com/zoncoen/scenarigo/pull/66/files#diff-5f1933881375b4c4729501a49ff3b1237f39204e6c3dedcb92884bee72520978L55