### PR TITLE
fix(template): don't convert invalid values to avoid panic

### DIFF
--- a/template/execute.go
+++ b/template/execute.go
@@ -138,9 +138,13 @@ func convert(t reflect.Type) func(reflect.Value, error) (reflect.Value, error) {
 			return v, err
 		}
 
+		if !v.IsValid() {
+			return v, nil
+		}
+
 		defer func() {
 			if err := recover(); err != nil {
-				resErr = errors.Errorf("failed to convert: %s", err)
+				resErr = errors.Errorf("failed to convert %#v to %s: %s", v.Interface(), t.Name(), err)
 			}
 		}()
 

--- a/template/execute_test.go
+++ b/template/execute_test.go
@@ -217,6 +217,16 @@ func TestConvert(t *testing.T) {
 			t.Fatalf("expect %s but got %s", expect, got)
 		}
 	})
+	t.Run("invalid value", func(t *testing.T) {
+		invalid := reflect.ValueOf(nil)
+		v, err := convertToStrPtr(invalid, nil)
+		if err != nil {
+			t.Fatalf("failed to convert: %s", err)
+		}
+		if got, expect := v, invalid; got != expect {
+			t.Fatalf("expect %s but got %s", expect, got)
+		}
+	})
 	t.Run("error", func(t *testing.T) {
 		_, err := convertToStrPtr(reflect.Value{}, errors.New("execute() failed"))
 		if err == nil {


### PR DESCRIPTION
`convert()` panics if the value is invalid.