### PR TITLE
test: allow to run tests on macos-latest

### DIFF
--- a/reporter/duration_test.go
+++ b/reporter/duration_test.go
@@ -1,6 +1,3 @@
-// NOTE: Fail on only macos-latest of GitHub Actions by duration errors.
-// +build !darwin
-
 package reporter
 
 import (
@@ -13,14 +10,16 @@ import (
 )
 
 func TestTestContext(t *testing.T) {
+	t.Parallel()
 	t.Run("serial", func(t *testing.T) {
+		t.Parallel()
 		ctx := newTestContext(WithMaxParallel(1))
 		if expect, got := 1, ctx.running; got != expect {
 			t.Errorf("expected %d but got %d", expect, got)
 		}
 
 		now := time.Now()
-		duration := 100 * time.Millisecond
+		duration := 10 * durationTestUnit
 		done := make(chan struct{})
 		go func() {
 			time.Sleep(duration)
@@ -32,7 +31,7 @@ func TestTestContext(t *testing.T) {
 		}()
 
 		ctx.waitParallel() // wait goroutine function
-		if expect, got := duration, time.Since(now).Truncate(10*time.Millisecond); got != expect {
+		if expect, got := duration, time.Since(now).Truncate(durationTestUnit); got != expect {
 			t.Errorf("expected %s but got %s", expect, got)
 		}
 		if expect, got := int64(0), ctx.waitings(); got != expect {
@@ -42,13 +41,14 @@ func TestTestContext(t *testing.T) {
 		<-done
 	})
 	t.Run("parallel", func(t *testing.T) {
+		t.Parallel()
 		ctx := newTestContext(WithMaxParallel(2))
 		if expect, got := 1, ctx.running; got != expect {
 			t.Errorf("expected %d but got %d", expect, got)
 		}
 
 		now := time.Now()
-		duration := 100 * time.Millisecond
+		duration := 10 * durationTestUnit
 		done := make(chan struct{})
 		go func() {
 			time.Sleep(duration)
@@ -60,7 +60,7 @@ func TestTestContext(t *testing.T) {
 		}()
 
 		ctx.waitParallel() // not wait goroutine function (run in parallel)
-		if expect, got := time.Duration(0), time.Since(now).Truncate(10*time.Millisecond); got != expect {
+		if expect, got := time.Duration(0), time.Since(now).Truncate(durationTestUnit); got != expect {
 			t.Errorf("expected %s but got %s", expect, got)
 		}
 		if expect, got := int64(0), ctx.waitings(); got != expect {
@@ -182,13 +182,13 @@ func TestRun(t *testing.T) {
 			maxParallel: 3,
 			fs: []func(r Reporter){
 				func(r Reporter) {
-					time.Sleep(100 * time.Millisecond)
+					time.Sleep(10 * durationTestUnit)
 				},
 				func(r Reporter) {
-					time.Sleep(100 * time.Millisecond)
+					time.Sleep(10 * durationTestUnit)
 				},
 				func(r Reporter) {
-					time.Sleep(100 * time.Millisecond)
+					time.Sleep(10 * durationTestUnit)
 				},
 			},
 			expect: result{
@@ -198,20 +198,20 @@ func TestRun(t *testing.T) {
 					{},
 				},
 			},
-			expectSerialDuration:   300 * time.Millisecond,
-			expectParallelDuration: 100 * time.Millisecond,
+			expectSerialDuration:   30 * durationTestUnit,
+			expectParallelDuration: 10 * durationTestUnit,
 		},
 		"run tests in parallel (max number of concurrent executions is 2)": {
 			maxParallel: 2,
 			fs: []func(r Reporter){
 				func(r Reporter) {
-					time.Sleep(100 * time.Millisecond)
+					time.Sleep(10 * durationTestUnit)
 				},
 				func(r Reporter) {
-					time.Sleep(100 * time.Millisecond)
+					time.Sleep(10 * durationTestUnit)
 				},
 				func(r Reporter) {
-					time.Sleep(100 * time.Millisecond)
+					time.Sleep(10 * durationTestUnit)
 				},
 			},
 			expect: result{
@@ -221,8 +221,8 @@ func TestRun(t *testing.T) {
 					{},
 				},
 			},
-			expectSerialDuration:   300 * time.Millisecond,
-			expectParallelDuration: 200 * time.Millisecond,
+			expectSerialDuration:   30 * durationTestUnit,
+			expectParallelDuration: 20 * durationTestUnit,
 		},
 	}
 	for name, test := range tests {
@@ -232,7 +232,9 @@ func TestRun(t *testing.T) {
 			opts = append(opts, WithMaxParallel(test.maxParallel))
 		}
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			t.Run("serial", func(t *testing.T) {
+				t.Parallel()
 				start := time.Now()
 				r := run(func(r Reporter) {
 					for i, f := range test.fs {
@@ -246,11 +248,12 @@ func TestRun(t *testing.T) {
 				if diff := cmp.Diff(test.expect, ignoreStackTrace(collectResult(r))); diff != "" {
 					t.Errorf("result mismatch (-want +got):\n%s", diff)
 				}
-				if expect, got := test.expectSerialDuration, duration.Truncate(50*time.Millisecond); got != expect {
+				if expect, got := test.expectSerialDuration, duration.Truncate(5*durationTestUnit); got != expect {
 					t.Errorf("expected %s but got %s", expect, got)
 				}
 			})
 			t.Run("parallel", func(t *testing.T) {
+				t.Parallel()
 				start := time.Now()
 				r := run(func(r Reporter) {
 					for i, f := range test.fs {
@@ -265,7 +268,7 @@ func TestRun(t *testing.T) {
 				if diff := cmp.Diff(test.expect, ignoreStackTrace(collectResult(r))); diff != "" {
 					t.Errorf("result mismatch (-want +got):\n%s", diff)
 				}
-				if expect, got := test.expectParallelDuration, duration.Truncate(50*time.Millisecond); got != expect {
+				if expect, got := test.expectParallelDuration, duration.Truncate(5*durationTestUnit); got != expect {
 					t.Errorf("expected %s but got %s", expect, got)
 				}
 			})

--- a/reporter/duration_unit_darwin_test.go
+++ b/reporter/duration_unit_darwin_test.go
@@ -1,0 +1,8 @@
+// NOTE: Increase the duration unit to avoid failing tests on macos-latest of GitHub Actions.
+// +build darwin
+
+package reporter
+
+import "time"
+
+const durationTestUnit = 1000 * time.Millisecond

--- a/reporter/duration_unit_test.go
+++ b/reporter/duration_unit_test.go
@@ -1,0 +1,7 @@
+// +build !darwin
+
+package reporter
+
+import "time"
+
+const durationTestUnit = 10 * time.Millisecond


### PR DESCRIPTION
I have skipped some tests that check duration measurement on only `macos-latest`. This PR enables to run it on `macos-latest` by increase the test duration unit.