### PR TITLE
feat(reporter): include the execution time of sub-tests

### DIFF
--- a/reporter/duration_measurer.go
+++ b/reporter/duration_measurer.go
@@ -1,0 +1,59 @@
+package reporter
+
+import (
+	"sync"
+	"time"
+)
+
+type testDurationMeasurer interface {
+	start()
+	stop()
+	spawn() testDurationMeasurer
+	getDuration() time.Duration
+}
+
+type durationMeasurer struct {
+	parent    *durationMeasurer
+	m         sync.Mutex
+	running   int
+	duration  time.Duration
+	startTime time.Time
+}
+
+func (m *durationMeasurer) start() {
+	if m == nil {
+		return
+	}
+	m.parent.start()
+	m.m.Lock()
+	defer m.m.Unlock()
+	if m.running == 0 {
+		m.startTime = time.Now()
+	}
+	m.running++
+}
+
+func (m *durationMeasurer) stop() {
+	if m == nil {
+		return
+	}
+	m.parent.stop()
+	m.m.Lock()
+	defer m.m.Unlock()
+	m.running--
+	if m.running == 0 {
+		m.duration += time.Since(m.startTime)
+	}
+}
+
+func (m *durationMeasurer) spawn() testDurationMeasurer {
+	return &durationMeasurer{
+		parent: m,
+	}
+}
+
+func (m *durationMeasurer) getDuration() time.Duration {
+	m.m.Lock()
+	defer m.m.Unlock()
+	return m.duration
+}

--- a/reporter/duration_measurer_test.go
+++ b/reporter/duration_measurer_test.go
@@ -1,0 +1,110 @@
+package reporter
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+var (
+	_ testDurationMeasurer = &durationMeasurer{}
+	_ testDurationMeasurer = &fixedDurationMeasurer{}
+)
+
+type fixedDurationMeasurer struct {
+	duration time.Duration
+}
+
+func (m *fixedDurationMeasurer) start() {
+}
+
+func (m *fixedDurationMeasurer) stop() {
+}
+
+func (m *fixedDurationMeasurer) spawn() testDurationMeasurer {
+	return &fixedDurationMeasurer{
+		duration: m.duration,
+	}
+}
+
+func (m *fixedDurationMeasurer) getDuration() time.Duration {
+	return m.duration
+}
+
+/*
+400ms parent
+300ms |-child1
+      | |-child1-1 |----->
+      | |-child1-2 |  ------>
+200ms |-child2     |  |  |  |
+        |-child2-1 |  --->  |
+        |-child2-2 |  |  |  |  --->
+                   |  |  |  |  |  |
+                   0  1  2  3  4  5 (100ms)
+*/
+func TestDurationMeasurer(t *testing.T) {
+	t.Parallel()
+
+	var wg sync.WaitGroup
+	ch := make(chan struct{})
+
+	parent := &durationMeasurer{}
+	child1 := parent.spawn()
+	child2 := parent.spawn()
+
+	// child1-1
+	wg.Add(1)
+	go func() {
+		<-ch
+		child1.start()
+		time.Sleep(20 * durationTestUnit)
+		child1.stop()
+		wg.Done()
+	}()
+
+	// child1-2
+	wg.Add(1)
+	go func() {
+		<-ch
+		time.Sleep(10 * durationTestUnit)
+		child1.start()
+		time.Sleep(20 * durationTestUnit)
+		child1.stop()
+		wg.Done()
+	}()
+
+	// child2-1
+	wg.Add(1)
+	go func() {
+		<-ch
+		time.Sleep(10 * durationTestUnit)
+		child2.start()
+		time.Sleep(10 * durationTestUnit)
+		child2.stop()
+		wg.Done()
+	}()
+
+	// child2-2
+	wg.Add(1)
+	go func() {
+		<-ch
+		time.Sleep(40 * durationTestUnit)
+		child2.start()
+		time.Sleep(10 * durationTestUnit)
+		child2.stop()
+		wg.Done()
+	}()
+
+	close(ch)
+	wg.Wait()
+
+	if expect, got := 40*durationTestUnit, parent.duration.Truncate(durationTestUnit); got != expect {
+		t.Errorf("expected %s but got %s", expect, got)
+	}
+	if expect, got := 30*durationTestUnit, child1.getDuration().Truncate(durationTestUnit); got != expect {
+		t.Errorf("expected %s but got %s", expect, got)
+	}
+	if expect, got := 20*durationTestUnit, child2.getDuration().Truncate(durationTestUnit); got != expect {
+		t.Errorf("expected %s but got %s", expect, got)
+	}
+}


### PR DESCRIPTION
Test duration time didn't include the execution time of sub-tests running in parallel. (this behavior from Go's test command) It is not intuitive, so this PR changes the specification.

## Verification

### code

```go
package main

import (
        "os"
        "testing"
        "time"

        "github.com/zoncoen/scenarigo/reporter"
)

func TestDuration(t *testing.T) {
        reporter.Run(func(r reporter.Reporter) {
                r.Run("example", func(r reporter.Reporter) {
                        r.Run("1", func(r reporter.Reporter) {
                                r.Parallel()
                                time.Sleep(time.Second)
                        })
                        r.Run("2", func(r reporter.Reporter) {
                                r.Parallel()
                                time.Sleep(time.Second)
                        })
                        r.Run("3", func(r reporter.Reporter) {
                                r.Parallel()
                                time.Sleep(time.Second)
                        })
                })
        }, reporter.WithWriter(os.Stdout), reporter.WithMaxParallel(3))
}
```

### before (current master branch)

```
--- PASS: example (0.00s)
    --- PASS: example/1 (1.00s)
    --- PASS: example/2 (1.00s)
    --- PASS: example/3 (1.00s)
```

### after

```
--- PASS: example (1.00s)
    --- PASS: example/1 (1.00s)
    --- PASS: example/2 (1.00s)
    --- PASS: example/3 (1.00s)
```

## Reference (Go's test command)

Go's test command doesn't include the execution time of sub-tests if the tests run in parallel.

```go
package main

import (
        "testing"
        "time"
)

func TestGoDuration(t *testing.T) {
        t.Run("1", func(t *testing.T) {
                t.Parallel()
                time.Sleep(time.Second)
        })
        t.Run("2", func(t *testing.T) {
                t.Parallel()
                time.Sleep(time.Second)
        })
        t.Run("3", func(t *testing.T) {
                t.Parallel()
                time.Sleep(time.Second)
        })
}
```

```
--- PASS: TestGoDuration (0.00s)
    --- PASS: TestGoDuration/3 (1.00s)
    --- PASS: TestGoDuration/1 (1.00s)
    --- PASS: TestGoDuration/2 (1.00s)
```

