### PR TITLE
feat(reporter): enable to generate test report

### DIFF
--- a/reporter/duration_test.go
+++ b/reporter/duration_test.go
@@ -287,7 +287,7 @@ func collectResult(r *reporter) result {
 	res := result{
 		Failed:  r.Failed(),
 		Skipped: r.Skipped(),
-		Logs:    r.logs,
+		Logs:    r.logs.all(),
 	}
 	for _, child := range r.children {
 		res.Children = append(res.Children, collectResult(child))

--- a/reporter/log.go
+++ b/reporter/log.go
@@ -1,0 +1,88 @@
+package reporter
+
+import "sync"
+
+type logRecorder struct {
+	m         sync.Mutex
+	strs      []string
+	infoIdxs  []int
+	errorIdxs []int
+	skipIdx   *int
+}
+
+func (r *logRecorder) log(s string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	r.strs = append(r.strs, s)
+	r.infoIdxs = append(r.infoIdxs, len(r.strs)-1)
+}
+
+func (r *logRecorder) error(s string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	r.strs = append(r.strs, s)
+	r.errorIdxs = append(r.errorIdxs, len(r.strs)-1)
+}
+
+func (r *logRecorder) skip(s string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	r.strs = append(r.strs, s)
+	i := len(r.strs) - 1
+	r.skipIdx = &i
+}
+
+func (r *logRecorder) all() []string {
+	r.m.Lock()
+	defer r.m.Unlock()
+	strs := make([]string, len(r.strs))
+	for i, str := range r.strs {
+		strs[i] = str
+	}
+	return strs
+}
+
+func (r *logRecorder) infoLogs() []string {
+	r.m.Lock()
+	defer r.m.Unlock()
+	ignore := map[int]struct{}{}
+	for _, i := range r.errorIdxs {
+		ignore[i] = struct{}{}
+	}
+	if r.skipIdx != nil {
+		ignore[*r.skipIdx] = struct{}{}
+	}
+	strs := make([]string, 0, len(r.strs)-len(ignore))
+	for i, str := range r.strs {
+		if _, ok := ignore[i]; ok {
+			continue
+		}
+		strs = append(strs, str)
+	}
+	if len(strs) == 0 {
+		return nil
+	}
+	return strs
+}
+
+func (r *logRecorder) errorLogs() []string {
+	r.m.Lock()
+	defer r.m.Unlock()
+	strs := make([]string, len(r.errorIdxs))
+	for i, j := range r.errorIdxs {
+		strs[i] = r.strs[j]
+	}
+	if len(strs) == 0 {
+		return nil
+	}
+	return strs
+}
+
+func (r *logRecorder) skipLog() *string {
+	r.m.Lock()
+	defer r.m.Unlock()
+	if r.skipIdx == nil {
+		return nil
+	}
+	return &r.strs[*r.skipIdx]
+}

--- a/reporter/log_test.go
+++ b/reporter/log_test.go
@@ -1,0 +1,44 @@
+package reporter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLogRecorder(t *testing.T) {
+	r := &logRecorder{}
+	r.log("info")
+	r.error("error")
+	r.skip("skip")
+
+	opts := []cmp.Option{
+		cmp.AllowUnexported(logRecorder{}),
+		cmp.FilterPath(func(p cmp.Path) bool {
+			return p.Last().String() == ".m"
+		}, cmp.Ignore()),
+	}
+	skipIdx := 2
+	if diff := cmp.Diff(&logRecorder{
+		strs:      []string{"info", "error", "skip"},
+		infoIdxs:  []int{0},
+		errorIdxs: []int{1},
+		skipIdx:   &skipIdx,
+	}, r, opts...); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+
+	skipLog := "skip"
+	if diff := cmp.Diff([]string{"info", "error", "skip"}, r.all()); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"info"}, r.infoLogs()); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"error"}, r.errorLogs()); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(&skipLog, r.skipLog()); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/reporter/report.go
+++ b/reporter/report.go
@@ -1,0 +1,371 @@
+package reporter
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/goccy/go-yaml"
+)
+
+// GenerateTestReport generates a test result report from r.
+func GenerateTestReport(r Reporter) (*TestReport, error) {
+	if r == nil {
+		return nil, errors.New("reporter is nil")
+	}
+	if !r.isRoot() {
+		return nil, errors.New("must be a root reporter")
+	}
+	report := &TestReport{
+		Name:   r.getName(),
+		Result: testResult(r),
+	}
+	for _, file := range r.getChildren() {
+		file := file
+		fileReport := ScenarioFileReport{
+			Name:     file.getName(),
+			Result:   testResult(file),
+			Duration: TestDuration(file.getDuration()),
+		}
+		for _, scenario := range file.getChildren() {
+			scenario := scenario
+			scenarioReport := ScenarioReport{
+				Name:     scenario.getName(),
+				File:     file.getName(),
+				Result:   testResult(scenario),
+				Duration: TestDuration(scenario.getDuration()),
+			}
+			for _, step := range scenario.getChildren() {
+				step := step
+				logs := step.getLogs()
+				stepReport := StepReport{
+					Name:     step.getName(),
+					Result:   testResult(step),
+					Duration: TestDuration(step.getDuration()),
+					Logs: ReportLogs{
+						Info:  logs.infoLogs(),
+						Error: logs.errorLogs(),
+						Skip:  logs.skipLog(),
+					},
+					SubSteps: generateSubStepReports(step),
+				}
+				scenarioReport.Steps = append(scenarioReport.Steps, stepReport)
+			}
+			fileReport.Scenarios = append(fileReport.Scenarios, scenarioReport)
+		}
+		report.Files = append(report.Files, fileReport)
+	}
+	return report, nil
+}
+
+func generateSubStepReports(r Reporter) []SubStepReport {
+	children := r.getChildren()
+	if len(children) == 0 {
+		return nil
+	}
+	reports := make([]SubStepReport, len(children))
+	for i, child := range children {
+		child := child
+		logs := child.getLogs()
+		reports[i] = SubStepReport{
+			Name:     child.getName(),
+			Result:   testResult(child),
+			Duration: TestDuration(child.getDuration()),
+			Logs: ReportLogs{
+				Info:  logs.infoLogs(),
+				Error: logs.errorLogs(),
+				Skip:  logs.skipLog(),
+			},
+			SubSteps: generateSubStepReports(child),
+		}
+	}
+	return reports
+}
+
+func testResult(r Reporter) TestResult {
+	if r.Failed() {
+		return TestResultFailed
+	}
+	if r.Skipped() {
+		return TestResultSkipped
+	}
+	return TestResultPassed
+}
+
+/*
+TestReport represents a test result report.
+This struct can be marshalled as JUnit-like format XML.
+
+	b, err := xml.MarshalIndent(test.report, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(b)
+
+*/
+type TestReport struct {
+	XMLName xml.Name             `json:"-" xml:"testsuites"`
+	Name    string               `json:"name,omitempty" xml:"name,attr,omitempty"`
+	Result  TestResult           `json:"result" xml:"-"`
+	Files   []ScenarioFileReport `json:"files" xml:"testsuite"`
+}
+
+// ScenarioFileReport represents a result report of a test scenario file.
+type ScenarioFileReport struct {
+	Name      string           `json:"name" xml:"name,attr,omitempty"`
+	Result    TestResult       `json:"result" xml:"-"`
+	Duration  TestDuration     `json:"duration" xml:"time,attr"`
+	Scenarios []ScenarioReport `json:"scenarios" xml:"testcase"`
+}
+
+type xmlScenarioFileReport ScenarioFileReport
+
+// MarshalXML implements xml.Marshaler interface.
+func (r ScenarioFileReport) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	var failures int
+	for _, scenario := range r.Scenarios {
+		scenario := scenario
+		if scenario.Result == TestResultFailed {
+			failures++
+		}
+	}
+	start.Attr = append(start.Attr,
+		xml.Attr{
+			Name: xml.Name{
+				Local: "tests",
+			},
+			Value: fmt.Sprint(len(r.Scenarios)),
+		},
+		xml.Attr{
+			Name: xml.Name{
+				Local: "failures",
+			},
+			Value: fmt.Sprint(failures),
+		},
+	)
+	return e.EncodeElement(xmlScenarioFileReport(r), start)
+}
+
+// ScenarioReport represents a result report of a test scenario.
+type ScenarioReport struct {
+	Name     string       `json:"name"`
+	File     string       `json:"-"`
+	Result   TestResult   `json:"result"`
+	Duration TestDuration `json:"duration"`
+	Steps    []StepReport `json:"steps"`
+}
+
+type xmlScenarioReport struct {
+	Name      string                   `xml:"name,attr,omitempty"`
+	File      string                   `xml:"file,attr,omitempty"`
+	Duration  TestDuration             `xml:"time,attr"`
+	Failure   *xmlScenarioReportDetail `xml:"failure,omitempty"`
+	Skipped   *xmlScenarioReportDetail `xml:"skipped,omitempty"`
+	SystemOut *xmlCDATA                `xml:"system-out,omitempty"`
+}
+
+type xmlScenarioReportDetail struct {
+	Message string `xml:"message,attr,omitempty"`
+	Logs    string `xml:",chardata"`
+}
+
+type xmlCDATA struct {
+	CDATA string `xml:",cdata"`
+}
+
+// MarshalXML implements xml.Marshaler interface.
+func (r ScenarioReport) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	xr := &xmlScenarioReport{
+		Name:     r.Name,
+		File:     r.File,
+		Duration: r.Duration,
+	}
+	switch r.Result {
+	case TestResultFailed:
+		for _, step := range r.Steps {
+			if step.Result == TestResultFailed {
+				if len(step.Logs.Info) > 0 {
+					xr.SystemOut = &xmlCDATA{
+						CDATA: strings.Join(step.Logs.Info, "\n"),
+					}
+				}
+				xr.Failure = &xmlScenarioReportDetail{
+					Message: step.Name,
+					Logs:    strings.Join(step.Logs.Error, "\n"),
+				}
+				break
+			}
+		}
+	case TestResultSkipped:
+		for _, step := range r.Steps {
+			if step.Result == TestResultSkipped {
+				xr.Skipped = &xmlScenarioReportDetail{
+					Message: step.Name,
+				}
+				if step.Logs.Skip != nil {
+					xr.Skipped.Logs = *step.Logs.Skip
+				}
+				break
+			}
+		}
+	default:
+	}
+	return e.EncodeElement(xr, start)
+}
+
+// StepReport represents a result report of a test scenario step.
+type StepReport struct {
+	Name     string          `json:"name"`
+	Result   TestResult      `json:"result"`
+	Duration TestDuration    `json:"duration"`
+	Logs     ReportLogs      `json:"logs"`
+	SubSteps []SubStepReport `json:"subSteps,omitempty"`
+}
+
+type ReportLogs struct {
+	Info  []string `json:"info,omitempty"`
+	Error []string `json:"error,omitempty"`
+	Skip  *string  `json:"skip,omitempty"`
+}
+
+// SubStepReport represents a result report of a test scenario sub step.
+type SubStepReport struct {
+	Name     string          `json:"name"`
+	Result   TestResult      `json:"result"`
+	Duration TestDuration    `json:"duration"`
+	Logs     ReportLogs      `json:"logs"`
+	SubSteps []SubStepReport `json:"subSteps,omitempty"`
+}
+
+// TestResult represents a test result.
+type TestResult int
+
+const (
+	TestResultUndefined TestResult = iota
+	TestResultPassed
+	TestResultFailed
+	TestResultSkipped
+
+	testResultUndefinedString = "undefined"
+	testResultPassedString    = "passed"
+	testResultFailedString    = "failed"
+	testResultSkippedString   = "skipped"
+)
+
+// String returns r as a string.
+func (r TestResult) String() string {
+	switch r {
+	case TestResultPassed:
+		return testResultPassedString
+	case TestResultFailed:
+		return testResultFailedString
+	case TestResultSkipped:
+		return testResultSkippedString
+	default:
+		return testResultUndefinedString
+	}
+}
+
+// MarshalJSON implements json.Marshaler interface.
+func (r TestResult) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%q", r.String())), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (r *TestResult) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	switch s {
+	case testResultPassedString:
+		*r = TestResultPassed
+	case testResultFailedString:
+		*r = TestResultFailed
+	case testResultSkippedString:
+		*r = TestResultSkipped
+	case testResultUndefinedString:
+		*r = TestResultUndefined
+	default:
+		return fmt.Errorf("invalid test result %s", s)
+	}
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler interface.
+func (r TestResult) MarshalYAML() ([]byte, error) {
+	return []byte(r.String()), nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler interface.
+func (r *TestResult) UnmarshalYAML(b []byte) error {
+	var s string
+	if err := yaml.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	switch s {
+	case testResultPassedString:
+		*r = TestResultPassed
+	case testResultFailedString:
+		*r = TestResultFailed
+	case testResultSkippedString:
+		*r = TestResultSkipped
+	case testResultUndefinedString:
+		*r = TestResultUndefined
+	default:
+		return fmt.Errorf("invalid test result %s", s)
+	}
+	return nil
+}
+
+// TestDuration represents an elapsed time of a test.
+type TestDuration time.Duration
+
+// MarshalJSON implements json.Marshaler interface.
+func (d TestDuration) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%q", time.Duration(d).String())), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (d *TestDuration) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	td, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*d = TestDuration(td)
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler interface.
+func (d TestDuration) MarshalYAML() ([]byte, error) {
+	return []byte(time.Duration(d).String()), nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler interface.
+func (d *TestDuration) UnmarshalYAML(b []byte) error {
+	var s string
+	if err := yaml.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	td, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*d = TestDuration(td)
+	return nil
+}
+
+// MarshalYAML implements xml.Marshaler interface.
+func (d TestDuration) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	return xml.Attr{
+		Name:  name,
+		Value: fmt.Sprintf("%f", time.Duration(d).Seconds()),
+	}, nil
+}

--- a/reporter/report_test.go
+++ b/reporter/report_test.go
@@ -1,0 +1,468 @@
+package reporter
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-yaml"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGenerateTestReport(t *testing.T) {
+	t.Run("passed", func(t *testing.T) {
+		tests := map[string]struct {
+			f      func(r Reporter)
+			expect *TestReport
+		}{
+			"all step passed": {
+				f: func(r Reporter) {
+					r.Run("file1.yaml", func(r Reporter) {
+						r.Run("scenario1", func(r Reporter) {
+							r.Run("step1", func(r Reporter) {
+							})
+						})
+					})
+				},
+				expect: &TestReport{
+					Result: TestResultPassed,
+					Files: []ScenarioFileReport{
+						{
+							Name:   "file1.yaml",
+							Result: TestResultPassed,
+							Scenarios: []ScenarioReport{
+								{
+									Name:   "scenario1",
+									File:   "file1.yaml",
+									Result: TestResultPassed,
+									Steps: []StepReport{
+										{
+											Name:   "step1",
+											Result: TestResultPassed,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"has sub steps (include)": {
+				f: func(r Reporter) {
+					r.Run("file1.yaml", func(r Reporter) {
+						r.Run("scenario1", func(r Reporter) {
+							r.Run("include base.yaml", func(r Reporter) {
+								r.Run("base.yaml", func(r Reporter) {
+									r.Run("base scenario", func(r Reporter) {
+										r.Run("base step", func(r Reporter) {
+											r.Log("base step")
+										})
+									})
+								})
+							})
+						})
+					})
+				},
+				expect: &TestReport{
+					Result: TestResultPassed,
+					Files: []ScenarioFileReport{
+						{
+							Name:   "file1.yaml",
+							Result: TestResultPassed,
+							Scenarios: []ScenarioReport{
+								{
+									Name:   "scenario1",
+									File:   "file1.yaml",
+									Result: TestResultPassed,
+									Steps: []StepReport{
+										{
+											Name:   "include base.yaml",
+											Result: TestResultPassed,
+											SubSteps: []SubStepReport{
+												{
+													Name:   "base.yaml",
+													Result: TestResultPassed,
+													SubSteps: []SubStepReport{
+														{
+															Name:   "base scenario",
+															Result: TestResultPassed,
+															SubSteps: []SubStepReport{
+																{
+																	Name:   "base step",
+																	Result: TestResultPassed,
+																	Logs: ReportLogs{
+																		Info: []string{
+																			"base step",
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		for name, test := range tests {
+			test := test
+			t.Run(name, func(t *testing.T) {
+				t.Run("reporter", func(t *testing.T) {
+					r := run(func(r Reporter) {
+						r.(*reporter).durationMeasurer = &fixedDurationMeasurer{}
+						test.f(r)
+					}, WithWriter(&nopWriter{}))
+					checkReport(t, r, test.expect)
+				})
+				t.Run("testReporter", func(t *testing.T) {
+					r := FromT(t)
+					r.(*testReporter).durationMeasurer = &fixedDurationMeasurer{}
+					test.f(r)
+					test.expect.Name = t.Name()
+					checkReport(t, r, test.expect)
+				})
+			})
+		}
+	})
+	t.Run("failed", func(t *testing.T) {
+		skipMsg := "skip"
+		tests := map[string]struct {
+			f      func(r Reporter)
+			expect *TestReport
+		}{
+			"step failed": {
+				f: func(r Reporter) {
+					r.Run("file1.yaml", func(r Reporter) {
+						r.Run("scenario1", func(r Reporter) {
+							r.Run("step1", func(r Reporter) {
+								r.Log("log")
+							})
+							r.Run("step2", func(r Reporter) {
+								r.Fatal("fatal")
+							})
+							r.Run("step3", func(r Reporter) {
+								r.Skip(skipMsg)
+							})
+						})
+					})
+				},
+				expect: &TestReport{
+					Result: TestResultFailed,
+					Files: []ScenarioFileReport{
+						{
+							Name:   "file1.yaml",
+							Result: TestResultFailed,
+							Scenarios: []ScenarioReport{
+								{
+									Name:   "scenario1",
+									File:   "file1.yaml",
+									Result: TestResultFailed,
+									Steps: []StepReport{
+										{
+											Name:   "step1",
+											Result: TestResultPassed,
+											Logs: ReportLogs{
+												Info: []string{
+													"log",
+												},
+											},
+										},
+										{
+											Name:   "step2",
+											Result: TestResultFailed,
+											Logs: ReportLogs{
+												Error: []string{
+													"fatal",
+												},
+											},
+										},
+										{
+											Name:   "step3",
+											Result: TestResultSkipped,
+											Logs: ReportLogs{
+												Skip: &skipMsg,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		for name, test := range tests {
+			test := test
+			t.Run(name, func(t *testing.T) {
+				t.Run("reporter", func(t *testing.T) {
+					r := run(func(r Reporter) {
+						r.(*reporter).durationMeasurer = &fixedDurationMeasurer{}
+						test.f(r)
+					}, WithWriter(&nopWriter{}))
+					checkReport(t, r, test.expect)
+				})
+			})
+		}
+	})
+	t.Run("error", func(t *testing.T) {
+		t.Run("nil", func(t *testing.T) {
+			if _, err := GenerateTestReport(nil); err == nil {
+				t.Fatal("no error")
+			}
+		})
+		t.Run("not root", func(t *testing.T) {
+			Run(func(r Reporter) {
+				r.Run("child", func(r Reporter) {
+					if _, err := GenerateTestReport(r); err == nil {
+						t.Fatal("no error")
+					}
+				})
+			}, WithWriter(&nopWriter{}))
+		})
+	})
+}
+
+func checkReport(t *testing.T, r Reporter, expect *TestReport) {
+	t.Helper()
+	report, err := GenerateTestReport(r)
+	if err != nil {
+		t.Fatalf("failed to generate report: %s", err)
+	}
+	if diff := cmp.Diff(expect, report); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTestResult(t *testing.T) {
+	tests := []struct {
+		result TestResult
+		expect string
+	}{
+		{
+			result: TestResultUndefined,
+			expect: "undefined",
+		},
+		{
+			result: TestResultPassed,
+			expect: "passed",
+		},
+		{
+			result: TestResultFailed,
+			expect: "failed",
+		},
+		{
+			result: TestResultSkipped,
+			expect: "skipped",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.expect, func(t *testing.T) {
+			t.Run("json", func(t *testing.T) {
+				b, err := json.Marshal(test.result)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got, expect := string(b), fmt.Sprintf("%q", test.expect); got != expect {
+					t.Fatalf("expect %q but got %q", expect, got)
+				}
+				var tr TestResult
+				if err := json.Unmarshal(b, &tr); err != nil {
+					t.Fatal(err)
+				}
+				if got, expect := tr.String(), test.result.String(); got != expect {
+					t.Fatalf("expect %q but got %q", expect, got)
+				}
+			})
+			t.Run("yaml", func(t *testing.T) {
+				b, err := yaml.Marshal(test.result)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got, expect := strings.TrimRight(string(b), "\n"), test.expect; got != expect {
+					t.Fatalf("expect %q but got %q", expect, got)
+				}
+				var tr TestResult
+				if err := yaml.Unmarshal(b, &tr); err != nil {
+					t.Fatal(err)
+				}
+				if got, expect := tr.String(), test.result.String(); got != expect {
+					t.Fatalf("expect %q but got %q", expect, got)
+				}
+			})
+		})
+	}
+}
+
+func TestTestDuration(t *testing.T) {
+	tests := []struct {
+		duration TestDuration
+		expect   string
+	}{
+		{
+			duration: 445506789000000,
+			expect:   "123h45m6.789s",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.expect, func(t *testing.T) {
+			t.Run("json", func(t *testing.T) {
+				b, err := json.Marshal(test.duration)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got, expect := string(b), fmt.Sprintf("%q", test.expect); got != expect {
+					t.Fatalf("expect %q but got %q", expect, got)
+				}
+				var d TestDuration
+				if err := json.Unmarshal(b, &d); err != nil {
+					t.Fatal(err)
+				}
+				if got, expect := d, test.duration; got != expect {
+					t.Fatalf("expect %q but got %q", expect, got)
+				}
+			})
+			t.Run("yaml", func(t *testing.T) {
+				b, err := yaml.Marshal(test.duration)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got, expect := strings.TrimRight(string(b), "\n"), test.expect; got != expect {
+					t.Fatalf("expect %q but got %q", expect, got)
+				}
+				var d TestDuration
+				if err := yaml.Unmarshal(b, &d); err != nil {
+					t.Fatal(err)
+				}
+				if got, expect := d, test.duration; got != expect {
+					t.Fatalf("expect %q but got %q", expect, got)
+				}
+			})
+		})
+	}
+}
+
+func TestTestReport_MarshalXML(t *testing.T) {
+	skipMsg := "skip"
+	tests := map[string]struct {
+		report *TestReport
+	}{
+		"passed": {
+			report: &TestReport{
+				Result: TestResultFailed,
+				Files: []ScenarioFileReport{
+					{
+						Name:     "file1.yaml",
+						Result:   TestResultFailed,
+						Duration: TestDuration(123 * time.Millisecond),
+						Scenarios: []ScenarioReport{
+							{
+								Name:     "passed scenario",
+								File:     "file1.yaml",
+								Result:   TestResultPassed,
+								Duration: TestDuration(100 * time.Millisecond),
+								Steps: []StepReport{
+									{
+										Name:     "passed step",
+										Result:   TestResultPassed,
+										Duration: TestDuration(100 * time.Millisecond),
+									},
+								},
+							},
+							{
+								Name:     "failed scenario",
+								File:     "file1.yaml",
+								Result:   TestResultFailed,
+								Duration: TestDuration(23 * time.Millisecond),
+								Steps: []StepReport{
+									{
+										Name:     "passed step",
+										Result:   TestResultPassed,
+										Duration: TestDuration(20 * time.Millisecond),
+										Logs: ReportLogs{
+											Info: []string{
+												"info",
+											},
+										},
+									},
+									{
+										Name:     "failed step",
+										Result:   TestResultFailed,
+										Duration: TestDuration(3 * time.Millisecond),
+										Logs: ReportLogs{
+											Info: []string{
+												"info",
+											},
+											Error: []string{
+												"error",
+											},
+										},
+									},
+									{
+										Name:   "skipped step",
+										Result: TestResultSkipped,
+										Logs: ReportLogs{
+											Skip: &skipMsg,
+										},
+									},
+								},
+							},
+							{
+								Name:   "skipped scenario",
+								File:   "file1.yaml",
+								Result: TestResultSkipped,
+								Steps: []StepReport{
+									{
+										Name:   "skipped step",
+										Result: TestResultSkipped,
+										Logs: ReportLogs{
+											Skip: &skipMsg,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			b, err := xml.MarshalIndent(test.report, "", "  ")
+			if err != nil {
+				t.Fatalf("failed to marshal: %s", err)
+			}
+
+			f, err := os.Open("testdata/report.xml")
+			if err != nil {
+				t.Fatalf("failed to open: %s", err)
+			}
+			defer f.Close()
+			expected, err := ioutil.ReadAll(f)
+			if err != nil {
+				t.Fatalf("failed to read: %s", err)
+			}
+
+			if diff := cmp.Diff(
+				strings.Trim(string(expected), "\n"),
+				string(b),
+			); diff != "" {
+				t.Errorf("result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/reporter/testdata/report.xml
+++ b/reporter/testdata/report.xml
@@ -1,0 +1,12 @@
+<testsuites>
+  <testsuite tests="3" failures="1" name="file1.yaml" time="0.123000">
+    <testcase name="passed scenario" file="file1.yaml" time="0.100000"></testcase>
+    <testcase name="failed scenario" file="file1.yaml" time="0.023000">
+      <failure message="failed step">error</failure>
+      <system-out><![CDATA[info]]></system-out>
+    </testcase>
+    <testcase name="skipped scenario" file="file1.yaml" time="0.000000">
+      <skipped message="skipped step">skip</skipped>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/step.go
+++ b/step.go
@@ -46,7 +46,9 @@ func runStep(ctx *context.Context, s *schema.Step, stepIdx int) *context.Context
 			ctx.Reporter().Fatalf(`failed to create ast: %s`, err)
 		}
 		currentNode := ctx.Node()
-		ctx = RunScenario(ctx.WithNode(includeNode), scenarios[0])
+		ctx.Run(scenarios[0].Filepath(), func(ctx *context.Context) {
+			RunScenario(ctx.WithNode(includeNode), scenarios[0])
+		})
 
 		// back node to current node
 		ctx = ctx.WithNode(currentNode)

--- a/test/e2e/testdata/plugins/simple/main.go
+++ b/test/e2e/testdata/plugins/simple/main.go
@@ -1,11 +1,29 @@
 package main
 
-import "io"
+import (
+	"io"
+
+	"github.com/goccy/go-yaml"
+
+	"github.com/zoncoen/scenarigo/context"
+	"github.com/zoncoen/scenarigo/plugin"
+	"github.com/zoncoen/scenarigo/schema"
+)
 
 var (
-	String    = "string"
-	Pointer   = &String
-	Interface = io.Reader(nil)
+	String       = "string"
+	Pointer      = &String
+	Interface    = io.Reader(nil)
+	DumpVarsStep = plugin.StepFunc(dumpVarsStep)
 )
 
 func Function() string { return "function" }
+
+func dumpVarsStep(ctx *context.Context, step *schema.Step) *context.Context {
+	b, err := yaml.Marshal(step.Vars)
+	if err != nil {
+		ctx.Reporter().Errorf("failed to marshal vars: %s", err)
+	}
+	ctx.Reporter().Log(string(b))
+	return ctx
+}

--- a/test/e2e/testdata/scenarios/included.yaml
+++ b/test/e2e/testdata/scenarios/included.yaml
@@ -1,0 +1,9 @@
+---
+title: included scenario
+plugins:
+  simple: simple.so
+steps:
+- title: step plugin
+  vars:
+    step: step 
+  ref: '{{plugins.simple.DumpVarsStep}}'

--- a/test/e2e/testdata/scenarios/report.yaml
+++ b/test/e2e/testdata/scenarios/report.yaml
@@ -1,0 +1,21 @@
+---
+title: /echo
+steps:
+- title: include
+  include: './included.yaml'
+- title: POST /echo
+  vars:
+    id: "123"
+    message: hello
+  protocol: http
+  request:
+    method: POST
+    url: "{{env.TEST_ADDR}}/echo"
+    header:
+      Authorization: "Bearer {{env.TEST_TOKEN}}"
+    body:
+      message: "{{vars.message}}"
+  expect:
+    code: 200
+    body:
+      message: "{{request.message}}"


### PR DESCRIPTION
Add a function `GenerateTestReport` that generates a test report `*TestReport`.
The report can be marshaled as JUnit-like format XML.

## Example

### code
```go
r, err := scenarigo.NewRunner(
    scenarigo.WithScenarios("testdata/example.yaml"),
)
if err != nil {
   panic(err)
}
ok := reporter.Run(func(rptr reporter.Reporter) {
    r.Run(context.New(rptr))

    # generate test result report from reporter
    report, err := reporter.GenerateTestReport(rptr)
    if err != nil {
        panic(err)
    }

    # print as JSON
    jb, err := json.MarshalIndent(report, "", "  ")
    if err != nil {
        panic(err)
    }
    fmt.Println(string(jb))

    # print as XML
    xb, err := xml.MarshalIndent(report, "", "  ")
    if err != nil {
        panic(err)
    }
    fmt.Println(string(xb))
})
if !ok {
    panic("test failed")
}
```

### JSON
```json
{
  "result": "passed",
  "files": [
    {
      "name": "testdata/example.yaml",
      "result": "passed",
      "duration": "1.0173ms",
      "scenarios": [
        {
          "name": "/echo",
          "result": "passed",
          "duration": "660.3µs",
          "steps": [
            {
              "name": "POST /echo",
              "result": "passed",
              "duration": "605µs",
              "logs": {
                "info": [
                  "[0] send request",
                  "request:\n  method: POST\n  url: http://127.0.0.1:39353/echo\n  header:\n    Authorization:\n    - Bearer XXXXX\n    User-Agent:\n    - scenarigo/v0.6.1-dev\n  body:\n    message: hello\n  ",
                  "response:\n  header:\n    Content-Length:\n    - \"27\"\n    Content-Type:\n    - application/json\n    Date:\n    - Thu, 25 Feb 2021 15:06:24 GMT\n  body:\n    id: \"\"\n    message: hello\n  ",
                  "elapsed time: 0.000531 sec"
                ]
              }
            }
          ]
        }
      ]
    }
  ]
}
```

### XML
```xml
<testsuites>
  <testsuite tests="1" failures="0" name="testdata/example.yaml" time="0.001017">
    <testcase name="/echo" file="testdata/example.yaml" time="0.000660"></testcase>
  </testsuite>
</testsuites>
```