### PR TITLE
fix: enable to bind vars defined in the included scenario

### DIFF
--- a/step.go
+++ b/step.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zoncoen/scenarigo/context"
 	"github.com/zoncoen/scenarigo/errors"
 	"github.com/zoncoen/scenarigo/plugin"
+	"github.com/zoncoen/scenarigo/reporter"
 	"github.com/zoncoen/scenarigo/schema"
 )
 
@@ -46,8 +47,8 @@ func runStep(ctx *context.Context, s *schema.Step, stepIdx int) *context.Context
 			ctx.Reporter().Fatalf(`failed to create ast: %s`, err)
 		}
 		currentNode := ctx.Node()
-		ctx.Run(scenarios[0].Filepath(), func(ctx *context.Context) {
-			RunScenario(ctx.WithNode(includeNode), scenarios[0])
+		ctx.Reporter().Run(scenarios[0].Filepath(), func(rptr reporter.Reporter) {
+			ctx = RunScenario(ctx.WithReporter(rptr).WithNode(includeNode), scenarios[0])
 		})
 
 		// back node to current node

--- a/test/e2e/testdata/scenarios/included.yaml
+++ b/test/e2e/testdata/scenarios/included.yaml
@@ -7,3 +7,6 @@ steps:
   vars:
     step: step 
   ref: '{{plugins.simple.DumpVarsStep}}'
+  bind:
+    vars:
+      include: true

--- a/test/e2e/testdata/scenarios/report.yaml
+++ b/test/e2e/testdata/scenarios/report.yaml
@@ -3,6 +3,9 @@ title: /echo
 steps:
 - title: include
   include: './included.yaml'
+  bind:
+    vars:
+      include: '{{vars.include}}'
 - title: POST /echo
   vars:
     id: "123"


### PR DESCRIPTION
Scenarigo enables to bind vars defined in the included scenario, but #83 makes it impossible.
This PR fixes it.