### PR TITLE
fix(assert): fix the assertion operators

### DIFF
--- a/context/assert_test.go
+++ b/context/assert_test.go
@@ -7,57 +7,30 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/zoncoen/scenarigo/assert"
+	"github.com/zoncoen/scenarigo/internal/testutil"
 	"github.com/zoncoen/scenarigo/template"
 )
 
-func TestOr(t *testing.T) {
-	tests := map[string]struct {
-		yaml string
-		ok   interface{}
-		ng   interface{}
-	}{
-		"simple": {
-			yaml: `'{{or("1")}}'`,
-			ok:   "1",
-			ng:   "one",
-		},
-		"assertion": {
-			yaml: `'{{or(notZero)}}'`,
-			ok:   "xxx",
-			ng:   "",
-		},
-		"left arrow function": {
-			yaml: strconv.Quote(strings.Trim(`
-{{or <-}}:
-  - "1"
-`, "\n")),
-			ok: "1",
-			ng: "one",
-		},
-	}
-	for name, tc := range tests {
-		tc := tc
-		t.Run(name, func(t *testing.T) {
-			var i interface{}
-			if err := yaml.Unmarshal([]byte(tc.yaml), &i); err != nil {
-				t.Fatalf("failed to unmarshal: %s", err)
-			}
-			v, err := template.Execute(i, map[string]interface{}{
-				"or":      assertions["or"],
-				"notZero": assertions["notZero"],
+func TestAssertions(t *testing.T) {
+	executor := func(r testutil.Reporter, decode func(interface{})) func(testutil.Reporter, interface{}) error {
+		var i interface{}
+		decode(&i)
+		return func(r testutil.Reporter, v interface{}) error {
+			a, err := template.Execute(i, map[string]interface{}{
+				"assert": assertions,
 			})
 			if err != nil {
-				t.Fatalf("failed to execute: %s", err)
+				r.Fatalf("failed to execute template: %s", err)
 			}
-			assertion := assert.Build(v)
-			if err := assertion.Assert(tc.ok); err != nil {
-				t.Errorf("unexpected error: %s", err)
-			}
-			if err := assertion.Assert(tc.ng); err == nil {
-				t.Errorf("expected error but no error")
-			}
-		})
+			return assert.Build(a).Assert(v)
+		}
 	}
+	testutil.RunParameterizedTests(
+		t, executor,
+		"testdata/assertion/and.yaml",
+		"testdata/assertion/or.yaml",
+		"testdata/assertion/contains.yaml",
+	)
 }
 
 func TestLeftArrowFunc(t *testing.T) {
@@ -97,7 +70,7 @@ func TestLeftArrowFunc(t *testing.T) {
 				t.Fatalf("failed to unmarshal: %s", err)
 			}
 			v, err := template.Execute(i, map[string]interface{}{
-				"f": leftArrowFunc(assert.Contains),
+				"f": leftArrowFunc(buildArg(assert.Contains)),
 			})
 			if err != nil {
 				t.Fatalf("failed to execute: %s", err)

--- a/context/testdata/assertion/and.yaml
+++ b/context/testdata/assertion/and.yaml
@@ -24,3 +24,22 @@ ok:
 - xxx
 ng:
 - yyy
+
+---
+name: left arrow function w/ assertion
+yaml: |-
+  {{assert.and <-}}:
+  - |-
+    {{assert.contains <-}}:
+      name: Alice
+  - |-
+    {{assert.contains <-}}:
+      name: Bob
+ok:
+-
+  - name: Alice
+  - name: Bob
+ng:
+-
+  - name: Bob
+  - name: Charlie

--- a/context/testdata/assertion/and.yaml
+++ b/context/testdata/assertion/and.yaml
@@ -1,0 +1,26 @@
+---
+name: simple
+yaml: '{{assert.and("1")}}'
+ok:
+- '1'
+ng:
+- one
+
+---
+name: w/ assertion
+yaml: '{{assert.and(assert.notZero)}}'
+ok:
+- xxx
+ng:
+- ''
+
+---
+name: left arrow function
+yaml: |-
+  {{assert.and <-}}:
+  - xxx
+  - '{{assert.notZero}}'
+ok:
+- xxx
+ng:
+- yyy

--- a/context/testdata/assertion/contains.yaml
+++ b/context/testdata/assertion/contains.yaml
@@ -1,0 +1,34 @@
+---
+name: simple
+yaml: '{{assert.contains(1)}}'
+ok:
+- [1]
+ng:
+- not array
+- []
+- [0]
+- ['1']
+
+---
+name: w/ assertion
+yaml: '{{assert.contains(assert.notZero)}}'
+ok:
+- [1]
+- ['1']
+ng:
+- [0]
+- ['']
+
+---
+name: left arrow function
+yaml: |-
+  {{assert.contains <-}}:
+    name: Alice
+ok:
+-
+  - name: Alice
+  - name: Bob
+ng:
+-
+  - name: Bob
+  - name: Charlie

--- a/context/testdata/assertion/or.yaml
+++ b/context/testdata/assertion/or.yaml
@@ -1,0 +1,26 @@
+---
+name: simple
+yaml: '{{assert.or("1")}}'
+ok:
+- '1'
+ng:
+- one
+
+---
+name: w/ assertion
+yaml: '{{assert.or(assert.notZero)}}'
+ok:
+- xxx
+ng:
+- ''
+
+---
+name: left arrow function
+yaml: |-
+  {{assert.or <-}}:
+  - yyy
+  - '{{assert.notZero}}'
+ok:
+- xxx
+ng:
+- ''

--- a/internal/testutil/parameterized.go
+++ b/internal/testutil/parameterized.go
@@ -1,0 +1,78 @@
+package testutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/goccy/go-yaml"
+)
+
+// RunParameterizedTests runs parameterized tests.
+func RunParameterizedTests(r Reporter, e ParameterizedTestExecutor, files ...string) {
+	r.Helper()
+	for _, file := range files {
+		file := file
+		run(r, file, func(r Reporter) {
+			f, err := os.Open(file)
+			if err != nil {
+				r.Fatalf("failed to open file: %s", err)
+			}
+			dec := yaml.NewDecoder(f, yaml.UseOrderedMap())
+			for {
+				var p TestParameter
+				if err := dec.Decode(&p); err != nil {
+					if err == io.EOF {
+						break
+					} else {
+						r.Fatalf("failed to decode test parameter: %s", err)
+					}
+				}
+				run(r, p.Name, func(r Reporter) {
+					exec := e(r, func(v interface{}) {
+						b, err := yaml.Marshal(p.YAML)
+						if err != nil {
+							r.Fatalf("failed to marshal YAML: %s", err)
+						}
+						if err := yaml.UnmarshalWithOptions(b, v, yaml.UseOrderedMap()); err != nil {
+							r.Fatalf("failed to unmarshal YAML: %s", err)
+						}
+					})
+					run(r, "OK", func(r Reporter) {
+						for i, ok := range p.OKs {
+							ok := ok
+							run(r, fmt.Sprint(i), func(r Reporter) {
+								err := exec(r, ok)
+								if err != nil {
+									r.Fatal(err)
+								}
+							})
+						}
+					})
+					run(r, "NG", func(r Reporter) {
+						for i, ng := range p.NGs {
+							ng := ng
+							run(r, fmt.Sprint(i), func(r Reporter) {
+								err := exec(r, ng)
+								if err == nil {
+									r.Fatal("no error")
+								}
+							})
+						}
+					})
+				})
+			}
+		})
+	}
+}
+
+// TestParameter is a parameters for parameterized testing.
+type TestParameter struct {
+	Name string        `yaml:"name"`
+	YAML interface{}   `yaml:"yaml"`
+	OKs  []interface{} `yaml:"ok"`
+	NGs  []interface{} `yaml:"ng"`
+}
+
+// ParameterizedTestExecutor represents a executor for parameterized testing.
+type ParameterizedTestExecutor func(Reporter, func(interface{})) func(Reporter, interface{}) error

--- a/internal/testutil/parameterized_test.go
+++ b/internal/testutil/parameterized_test.go
@@ -1,0 +1,108 @@
+package testutil
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRunParameterizedTests_Success(t *testing.T) {
+	var yml interface{}
+	values := []interface{}{}
+	executor := func(r Reporter, decode func(interface{})) func(Reporter, interface{}) error {
+		decode(&yml)
+		return func(r Reporter, v interface{}) error {
+			values = append(values, v)
+			if s, ok := v.(string); ok {
+				if strings.HasPrefix(s, "ok-") {
+					return nil
+				}
+			}
+			return errors.New("ng")
+		}
+	}
+
+	r := &reporter{}
+	RunParameterizedTests(r, executor, "testdata/parameterized-success.yaml")
+	if r.Failed() {
+		t.Fatal("test failed")
+	}
+
+	if diff := cmp.Diff(
+		yaml.MapSlice{
+			{Key: "key", Value: "value"},
+		},
+		yml,
+	); diff != "" {
+		t.Errorf("(-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(
+		[]interface{}{
+			"ok-1", "ok-2", "ng-1", "ng-2",
+		},
+		values,
+	); diff != "" {
+		t.Errorf("(-want +got):\n%s", diff)
+	}
+}
+
+func TestRunParameterizedTests_Failure(t *testing.T) {
+	t.Run("file not found", func(t *testing.T) {
+		r := &reporter{}
+		executor := func(r Reporter, decode func(interface{})) func(Reporter, interface{}) error {
+			return func(r Reporter, v interface{}) error {
+				return nil
+			}
+		}
+		RunParameterizedTests(r, executor, "testdata/not-found.yaml")
+		if !r.Failed() {
+			t.Fatal("test passed")
+		}
+	})
+
+	t.Run("invalid YAML", func(t *testing.T) {
+		r := &reporter{}
+		executor := func(r Reporter, decode func(interface{})) func(Reporter, interface{}) error {
+			return func(r Reporter, v interface{}) error {
+				return nil
+			}
+		}
+		RunParameterizedTests(r, executor, "testdata/parameterized-invalid.yaml")
+		if !r.Failed() {
+			t.Fatal("test passed")
+		}
+	})
+
+	t.Run("failed parameter", func(t *testing.T) {
+		values := []interface{}{}
+		executor := func(r Reporter, decode func(interface{})) func(Reporter, interface{}) error {
+			return func(r Reporter, v interface{}) error {
+				values = append(values, v)
+				if s, ok := v.(string); ok {
+					if s == "ok" {
+						return nil
+					}
+				}
+				return errors.New("ng")
+			}
+		}
+
+		r := &reporter{}
+		RunParameterizedTests(r, executor, "testdata/parameterized-failure.yaml")
+		if !r.Failed() {
+			t.Fatal("test passed")
+		}
+
+		if diff := cmp.Diff(
+			[]interface{}{
+				"ng", "ok",
+			},
+			values,
+		); diff != "" {
+			t.Errorf("(-want +got):\n%s", diff)
+		}
+	})
+}

--- a/internal/testutil/reporter.go
+++ b/internal/testutil/reporter.go
@@ -1,0 +1,66 @@
+package testutil
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+)
+
+// A Reporter is something that can be used to report test failures.
+// It is satisfied by the standard library's *testing.T.
+type Reporter interface {
+	Fail()
+	Failed() bool
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Helper()
+}
+
+type reporter struct {
+	failed int32
+}
+
+// Fail marks the function as having failed but continues execution.
+func (r *reporter) Fail() {
+	atomic.StoreInt32(&r.failed, 1)
+}
+
+// Failed reports whether the function has failed.
+func (r *reporter) Failed() bool {
+	return atomic.LoadInt32(&r.failed) > 0
+}
+
+// Fatal is equivalent to Log followed by FailNow.
+func (r *reporter) Fatal(args ...interface{}) {
+	r.Fail()
+	panic(fmt.Sprint(args...))
+}
+
+// Fatalf is equivalent to Logf followed by FailNow.
+func (r *reporter) Fatalf(format string, args ...interface{}) {
+	r.Fatal(fmt.Sprintf(format, args...))
+}
+
+// Helper marks the calling function as a test helper function.
+func (r *reporter) Helper() {}
+
+func run(r Reporter, name string, f func(r Reporter)) {
+	switch t := r.(type) {
+	case *testing.T:
+		t.Run(name, func(t *testing.T) {
+			f(t)
+		})
+	default:
+		child := &reporter{}
+		defer func() {
+			err := recover()
+			if err != nil {
+				fmt.Println(err)
+			}
+			if child.Failed() {
+				r.Fail()
+			}
+		}()
+		f(child)
+	}
+}

--- a/internal/testutil/testdata/parameterized-failure.yaml
+++ b/internal/testutil/testdata/parameterized-failure.yaml
@@ -1,0 +1,9 @@
+---
+name: not ok
+ok:
+  - ng
+
+---
+name: not ng
+ng:
+  - ok

--- a/internal/testutil/testdata/parameterized-invalid.yaml
+++ b/internal/testutil/testdata/parameterized-invalid.yaml
@@ -1,0 +1,5 @@
+---
+name: invalid yaml
+yaml: {{}}
+ng:
+  - no use

--- a/internal/testutil/testdata/parameterized-success.yaml
+++ b/internal/testutil/testdata/parameterized-success.yaml
@@ -1,0 +1,10 @@
+---
+name: example
+yaml:
+  key: value
+ok:
+  - ok-1
+  - ok-2
+ng:
+  - ng-1
+  - ng-2

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -397,3 +397,11 @@ func (*callFunc) UnmarshalArg(unmarshal func(interface{}) error) (interface{}, e
 	}
 	return &arg, nil
 }
+
+func TestFuncStash(t *testing.T) {
+	var s funcStash
+	name := s.save("value")
+	if s[name] != "value" {
+		t.Fatal("failed to save")
+	}
+}


### PR DESCRIPTION
Left arrow functions require arguments must be a string to decode it as YAML. Because of that, I added a workaround that replacing assert functions with strings temporarily. This PR will fix a bug of the workaround.