### PR TITLE
fix(grpc): rename body field to message

### DIFF
--- a/protocol/grpc/expect_test.go
+++ b/protocol/grpc/expect_test.go
@@ -68,7 +68,7 @@ func TestExpect_Build(t *testing.T) {
 			"assert body": {
 				expect: &Expect{
 					Code: "OK",
-					Body: yaml.MapSlice{
+					Message: yaml.MapSlice{
 						yaml.MapItem{
 							Key:   "messageId",
 							Value: "1",
@@ -194,7 +194,7 @@ func TestExpect_Build(t *testing.T) {
 				vars: map[string]string{"body": "hello"},
 				expect: &Expect{
 					Code: "OK",
-					Body: yaml.MapSlice{
+					Message: yaml.MapSlice{
 						yaml.MapItem{
 							Key:   "messageId",
 							Value: "1",
@@ -243,7 +243,7 @@ func TestExpect_Build(t *testing.T) {
 			"failed to execute template": {
 				expect: &Expect{
 					Code: "OK",
-					Body: yaml.MapSlice{
+					Message: yaml.MapSlice{
 						yaml.MapItem{
 							Key:   "messageId",
 							Value: "1",
@@ -338,7 +338,7 @@ func TestExpect_Build(t *testing.T) {
 			"wrong body": {
 				expect: &Expect{
 					Code: "OK",
-					Body: yaml.MapSlice{
+					Message: yaml.MapSlice{
 						yaml.MapItem{
 							Key:   "messageId",
 							Value: "1",

--- a/protocol/grpc/grpc.go
+++ b/protocol/grpc/grpc.go
@@ -23,7 +23,7 @@ func (p *GRPC) Name() string {
 // UnmarshalRequest implements protocol.Protocol interface.
 func (p *GRPC) UnmarshalRequest(b []byte) (protocol.Invoker, error) {
 	var r Request
-	if err := yaml.Unmarshal(b, &r); err != nil {
+	if err := yaml.UnmarshalWithOptions(b, &r, yaml.Strict()); err != nil {
 		return nil, err
 	}
 

--- a/protocol/grpc/grpc.go
+++ b/protocol/grpc/grpc.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/goccy/go-yaml"
 	"github.com/zoncoen/scenarigo/protocol"
@@ -25,6 +26,16 @@ func (p *GRPC) UnmarshalRequest(b []byte) (protocol.Invoker, error) {
 	if err := yaml.Unmarshal(b, &r); err != nil {
 		return nil, err
 	}
+
+	// for backward compatibility
+	if r.Body != nil {
+		if r.Message != nil {
+			return nil, errors.New("body is deprecated, use message field only")
+		}
+		r.Message = r.Body
+		r.Body = nil
+	}
+
 	return &r, nil
 }
 
@@ -38,5 +49,15 @@ func (p *GRPC) UnmarshalExpect(b []byte) (protocol.AssertionBuilder, error) {
 	if err := decoder.Decode(&e); err != nil {
 		return nil, err
 	}
+
+	// for backward compatibility
+	if e.Body != nil {
+		if e.Message != nil {
+			return nil, errors.New("body is deprecated, use message field only")
+		}
+		e.Message = e.Body
+		e.Body = nil
+	}
+
 	return &e, nil
 }

--- a/protocol/grpc/grpc_test.go
+++ b/protocol/grpc/grpc_test.go
@@ -54,6 +54,14 @@ func TestGRPC_UnmarshalRequest(t *testing.T) {
 		tests := map[string]struct {
 			bytes []byte
 		}{
+			"unknown field": {
+				bytes: []byte(`a: b`),
+			},
+			"duplicated field": {
+				bytes: []byte(`
+method: Ping
+method: Ping`),
+			},
 			"use body and message": {
 				bytes: []byte(`
 body: test

--- a/protocol/grpc/request_test.go
+++ b/protocol/grpc/request_test.go
@@ -36,7 +36,7 @@ func TestRequest_Invoke(t *testing.T) {
 			r := &Request{
 				Client: "{{vars.client}}",
 				Method: "Echo",
-				Body: yaml.MapSlice{
+				Message: yaml.MapSlice{
 					yaml.MapItem{Key: "messageId", Value: "1"},
 					yaml.MapItem{Key: "messageBody", Value: "hello"},
 				},
@@ -82,7 +82,7 @@ func TestRequest_Invoke(t *testing.T) {
 			r := &Request{
 				Client: "{{vars.client}}",
 				Method: "Echo",
-				Body: yaml.MapSlice{
+				Message: yaml.MapSlice{
 					yaml.MapItem{Key: "messageId", Value: "1"},
 					yaml.MapItem{Key: "messageBody", Value: "hello"},
 				},
@@ -194,7 +194,7 @@ func TestRequest_Invoke_Log(t *testing.T) {
 		Metadata: map[string]string{
 			"version": "1.0.0",
 		},
-		Body: yaml.MapSlice{
+		Message: yaml.MapSlice{
 			yaml.MapItem{Key: "messageId", Value: "1"},
 			yaml.MapItem{Key: "messageBody", Value: "hello"},
 		},
@@ -220,12 +220,12 @@ func TestRequest_Invoke_Log(t *testing.T) {
           metadata:
             version:
             - 1.0.0
-          body:
+          message:
             messageId: "1"
             messageBody: hello
           
         response:
-          body:
+          message:
             messageId: "1"
             messageBody: hello
           
@@ -360,7 +360,7 @@ func TestBuildRequestBody(t *testing.T) {
 				ctx = ctx.WithVars(tc.vars)
 			}
 			var req test.EchoRequest
-			err := buildRequestBody(ctx, &req, tc.src)
+			err := buildRequestMsg(ctx, &req, tc.src)
 			if err != nil {
 				if !tc.error {
 					t.Fatalf("unexpected error: %s", err)

--- a/protocol/http/http.go
+++ b/protocol/http/http.go
@@ -22,7 +22,7 @@ func (p *HTTP) Name() string {
 // UnmarshalRequest implements protocol.Protocol interface.
 func (p *HTTP) UnmarshalRequest(b []byte) (protocol.Invoker, error) {
 	var r Request
-	if err := yaml.Unmarshal(b, &r); err != nil {
+	if err := yaml.UnmarshalWithOptions(b, &r, yaml.Strict()); err != nil {
 		return nil, err
 	}
 	return &r, nil

--- a/protocol/http/http_test.go
+++ b/protocol/http/http_test.go
@@ -6,6 +6,64 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestHTTP_UnmarshalRequest(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		tests := map[string]struct {
+			bytes  []byte
+			expect *Request
+		}{
+			"default": {
+				bytes:  nil,
+				expect: &Request{},
+			},
+			"method": {
+				bytes: []byte(`method: GET`),
+				expect: &Request{
+					Method: "GET",
+				},
+			},
+		}
+		for name, test := range tests {
+			test := test
+			t.Run(name, func(t *testing.T) {
+				p := &HTTP{}
+				invoker, err := p.UnmarshalRequest(test.bytes)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				if diff := cmp.Diff(test.expect, invoker); diff != "" {
+					t.Errorf("request differs (-want +got):\n%s", diff)
+				}
+			})
+		}
+	})
+
+	t.Run("ng", func(t *testing.T) {
+		tests := map[string]struct {
+			bytes []byte
+		}{
+			"unknown field": {
+				bytes: []byte(`a: b`),
+			},
+			"duplicated field": {
+				bytes: []byte(`
+method: GET
+method: GET`),
+			},
+		}
+		for name, test := range tests {
+			test := test
+			t.Run(name, func(t *testing.T) {
+				p := &HTTP{}
+				_, err := p.UnmarshalRequest(test.bytes)
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+			})
+		}
+	})
+}
+
 func TestHTTP_UnmarshalExpect(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		tests := map[string]struct {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/goccy/go-yaml"
-	"github.com/google/go-cmp/cmp"
 	"github.com/zoncoen/scenarigo"
 	"github.com/zoncoen/scenarigo/context"
 	"github.com/zoncoen/scenarigo/internal/testutil"
@@ -80,8 +79,10 @@ func TestE2E(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					if diff := cmp.Diff(string(stdout), testutil.ResetDuration(b.String())); diff != "" {
-						t.Errorf("stdout differs (-want +got):\n%s", diff)
+					if expect, got := string(stdout), testutil.ResetDuration(b.String()); expect != got {
+						t.Logf("===== expect =====\n%s", expect)
+						t.Logf("===== got =====\n%s", got)
+						t.FailNow()
 					}
 				})
 			}

--- a/test/e2e/testdata/scenarios/grpc.yaml
+++ b/test/e2e/testdata/scenarios/grpc.yaml
@@ -16,12 +16,12 @@ steps:
     method: Echo
     metadata:
       token: "{{env.TEST_TOKEN}}"
-    body:
+    message:
       messageId: "{{vars.id}}"
       messageBody: "{{vars.message}}"
   expect:
     code: OK
-    body:
+    message:
       messageId: "{{request.messageId}}"
       messageBody: "{{request.messageBody}}"
       nullableString: null

--- a/test/e2e/testdata/testcases/backward-compatibility.yaml
+++ b/test/e2e/testdata/testcases/backward-compatibility.yaml
@@ -1,0 +1,14 @@
+title: backward compatibility
+scenarios:
+- filename: backward-compatibility/body.yaml
+  success: true
+  output:
+    stdout: backward-compatibility/body.yaml
+- filename: backward-compatibility/request-body-and-message.yaml
+  success: false
+  output:
+    stdout: backward-compatibility/request-body-and-message.yaml
+- filename: backward-compatibility/expect-body-and-message.yaml
+  success: false
+  output:
+    stdout: backward-compatibility/expect-body-and-message.yaml

--- a/test/e2e/testdata/testcases/scenarios/backward-compatibility/body.yaml
+++ b/test/e2e/testdata/testcases/scenarios/backward-compatibility/body.yaml
@@ -1,0 +1,20 @@
+---
+title: use body field
+plugins:
+  grpc: "grpc.so"
+steps:
+- title: Echo
+  protocol: grpc
+  request:
+    client: '{{plugins.grpc.CreateClient(ctx, env.TEST_GRPC_SERVER_ADDR)}}'
+    method: Echo
+    metadata:
+      token: "{{env.TEST_TOKEN}}"
+    body:
+      messageId: xxx
+      messageBody: hello
+  expect:
+    code: OK
+    body:
+      messageId: "{{request.messageId}}"
+      messageBody: "{{request.messageBody}}"

--- a/test/e2e/testdata/testcases/scenarios/backward-compatibility/expect-body-and-message.yaml
+++ b/test/e2e/testdata/testcases/scenarios/backward-compatibility/expect-body-and-message.yaml
@@ -1,0 +1,20 @@
+---
+title: use body and message
+plugins:
+  grpc: "grpc.so"
+steps:
+- title: Echo
+  protocol: grpc
+  request:
+    client: '{{plugins.grpc.CreateClient(ctx, env.TEST_GRPC_SERVER_ADDR)}}'
+    method: Echo
+    metadata:
+      token: "{{env.TEST_TOKEN}}"
+    message:
+      messageId: xxx
+  expect:
+    code: OK
+    body:
+      messageId: "{{request.messageId}}"
+    message:
+      messageId: "{{request.messageId}}"

--- a/test/e2e/testdata/testcases/scenarios/backward-compatibility/request-body-and-message.yaml
+++ b/test/e2e/testdata/testcases/scenarios/backward-compatibility/request-body-and-message.yaml
@@ -1,0 +1,16 @@
+---
+title: use body and message
+plugins:
+  grpc: "grpc.so"
+steps:
+- title: Echo
+  protocol: grpc
+  request:
+    client: '{{plugins.grpc.CreateClient(ctx, env.TEST_GRPC_SERVER_ADDR)}}'
+    method: Echo
+    metadata:
+      token: "{{env.TEST_TOKEN}}"
+    body:
+      messageId: xxx
+    message:
+      messageId: xxx

--- a/test/e2e/testdata/testcases/scenarios/grpc-enum.yaml
+++ b/test/e2e/testdata/testcases/scenarios/grpc-enum.yaml
@@ -11,7 +11,7 @@ steps:
       token: "{{env.TEST_TOKEN}}"
   expect:
     code: OK
-    body:
+    message:
       userType: 1
 
 ---
@@ -27,5 +27,5 @@ steps:
       token: "{{env.TEST_TOKEN}}"
   expect:
     code: OK
-    body:
+    message:
       userType: "CUSTOMER"

--- a/test/e2e/testdata/testcases/stdout/backward-compatibility/body.yaml
+++ b/test/e2e/testdata/testcases/stdout/backward-compatibility/body.yaml
@@ -1,0 +1,1 @@
+ok  	testdata/testcases/scenarios/backward-compatibility/body.yaml	0.000s

--- a/test/e2e/testdata/testcases/stdout/backward-compatibility/expect-body-and-message.yaml
+++ b/test/e2e/testdata/testcases/stdout/backward-compatibility/expect-body-and-message.yaml
@@ -1,0 +1,5 @@
+--- FAIL: testdata/testcases/scenarios/backward-compatibility/expect-body-and-message.yaml (0.00s)
+        failed to load scenarios: failed to decode YAML: body is deprecated, use message field only
+FAIL
+FAIL	testdata/testcases/scenarios/backward-compatibility/expect-body-and-message.yaml	0.000s
+FAIL

--- a/test/e2e/testdata/testcases/stdout/backward-compatibility/request-body-and-message.yaml
+++ b/test/e2e/testdata/testcases/stdout/backward-compatibility/request-body-and-message.yaml
@@ -1,0 +1,5 @@
+--- FAIL: testdata/testcases/scenarios/backward-compatibility/request-body-and-message.yaml (0.00s)
+        failed to load scenarios: failed to decode YAML: body is deprecated, use message field only
+FAIL
+FAIL	testdata/testcases/scenarios/backward-compatibility/request-body-and-message.yaml	0.000s
+FAIL


### PR DESCRIPTION
The payload of gRPC is called "message", not "body".
The `body` field maps to the `message` field for backward compatibility.