### PR TITLE
refactor: don't use ioutil package

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -11,6 +11,14 @@
 {{ end }}
 {{ end -}}
 {{ end -}}
+{{- if .Unreleased.NoteGroups -}}
+{{ range .Unreleased.NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
 {{ end -}}
 
 {{ range .Versions -}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: [1.14.x, 1.15.x, 1.16.x]
+        go-version: [1.16.x]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ $ scenarigo run github.yaml
 
 #### Use as Go package
 
+This package requires Go 1.16 or later.
+
 ```go main_test.go
 package main
 

--- a/protocol/http/request.go
+++ b/protocol/http/request.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -93,7 +92,7 @@ func (r *Request) Invoke(ctx *context.Context) (*context.Context, interface{}, e
 		reader = resp.Body
 	}
 
-	b, err := ioutil.ReadAll(reader)
+	b, err := io.ReadAll(reader)
 	if err != nil {
 		return ctx, nil, errors.Errorf("failed to read response body: %s", err)
 	}

--- a/reporter/report_test.go
+++ b/reporter/report_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -452,7 +452,7 @@ func TestTestReport_MarshalXML(t *testing.T) {
 				t.Fatalf("failed to open: %s", err)
 			}
 			defer f.Close()
-			expected, err := ioutil.ReadAll(f)
+			expected, err := io.ReadAll(f)
 			if err != nil {
 				t.Fatalf("failed to read: %s", err)
 			}

--- a/scenario_test.go
+++ b/scenario_test.go
@@ -2,7 +2,7 @@ package scenarigo
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/zoncoen/scenarigo/context"
@@ -47,7 +47,7 @@ steps:
 
 func createTempScenario(t *testing.T, scenario string) string {
 	t.Helper()
-	f, err := ioutil.TempFile("", "*.yaml")
+	f, err := os.CreateTemp("", "*.yaml")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %s", err)
 	}

--- a/schema/load.go
+++ b/schema/load.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
@@ -22,7 +21,7 @@ func LoadScenarios(path string) ([]*Scenario, error) {
 
 // LoadScenariosFromReader loads test scenarios with io.Reader.
 func LoadScenariosFromReader(r io.Reader) ([]*Scenario, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read")
 	}

--- a/template/parser/scanner.go
+++ b/template/parser/scanner.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -173,7 +172,7 @@ func (s *scanner) scan() (int, token.Token, string) {
 			if ch := s.read(); ch != ':' {
 				return s.pos - 1, token.ILLEGAL, string(ch)
 			}
-			b, err := ioutil.ReadAll(s.r)
+			b, err := io.ReadAll(s.r)
 			if err != nil {
 				return s.pos, token.ILLEGAL, err.Error()
 			}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4,7 +4,7 @@ package scenarigo
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -22,7 +22,7 @@ import (
 
 func TestE2E(t *testing.T) {
 	dir := "testdata/testcases"
-	infos, err := ioutil.ReadDir(dir)
+	infos, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestE2E(t *testing.T) {
 					}
 					defer f.Close()
 
-					stdout, err := ioutil.ReadAll(f)
+					stdout, err := io.ReadAll(f)
 					if err != nil {
 						t.Fatal(err)
 					}


### PR DESCRIPTION
ioutil package to be deprecated in Go 1.16.
BREAKING CHANGE: This package requires Go 1.16 or later.