### PR TITLE
Add indents to keep the YAML string structure of left arrow function arguments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,7 @@ jobs:
       run: make test/ci
     - name: Upload coverage
       if: matrix.os == 'ubuntu-latest' && startsWith(matrix.go-version, '1.16')
-      uses: codecov/codecov-action@v1.5.0
+      uses: codecov/codecov-action@v2
       with:
         file: ./coverage.out
         fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 70%
+comment: off

--- a/internal/reflectutil/set.go
+++ b/internal/reflectutil/set.go
@@ -1,0 +1,67 @@
+package reflectutil
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/pkg/errors"
+)
+
+// Set assigns v to the value target.
+func Set(target, v reflect.Value) (retErr error) {
+	if !target.IsValid() {
+		return errors.New("can not set to invalid value")
+	}
+	if !v.IsValid() {
+		return nil
+	}
+	defer func() {
+		if err := recover(); err != nil {
+			retErr = fmt.Errorf("can not set %s to %s: %s", v.Type().String(), target.Type().String(), err)
+		}
+	}()
+	if vv, ok, err := Convert(target.Type(), v); err == nil && ok {
+		v = vv
+	}
+	if !target.CanSet() {
+		if !target.CanAddr() {
+			return fmt.Errorf("can not set to unaddressable value")
+		}
+		return fmt.Errorf("can not set to unexported struct field")
+	}
+	if !v.Type().AssignableTo(target.Type()) {
+		return fmt.Errorf("%s is not assignable to %s", v.Type().String(), target.Type().String())
+	}
+	target.Set(v)
+	return nil
+}
+
+// Convert returns the value v converted to type t.
+func Convert(t reflect.Type, v reflect.Value) (ret reflect.Value, ok bool, retErr error) {
+	if !v.IsValid() {
+		return v, false, nil
+	}
+	defer func() {
+		if err := recover(); err != nil {
+			retErr = errors.Errorf("failed to convert %T to %s: %s", v.Interface(), t.Name(), err)
+		}
+	}()
+
+	if v.Type().ConvertibleTo(t) {
+		return v.Convert(t), true, nil
+	} else {
+		if v.Type().Kind() == reflect.Ptr {
+			if v.Elem().Type().ConvertibleTo(t) {
+				return v.Elem().Convert(t), true, nil
+			}
+		} else {
+			ptr := reflect.New(v.Type())
+			ptr.Elem().Set(v)
+			if ptr.Type().ConvertibleTo(t) {
+				return ptr.Convert(t), true, nil
+			}
+		}
+	}
+
+	return v, false, nil
+}

--- a/template/execute_test.go
+++ b/template/execute_test.go
@@ -168,6 +168,15 @@ func TestExecute(t *testing.T) {
 			in:       &iface,
 			expected: "test",
 		},
+		"variable is a template string": {
+			in:       "{{a}}",
+			expected: "test",
+			vars: map[string]string{
+				"a": "{{b}}",
+				"b": "{{c}}",
+				"c": "test",
+			},
+		},
 	}
 	for name, test := range tests {
 		test := test

--- a/template/execute_test.go
+++ b/template/execute_test.go
@@ -194,7 +194,6 @@ func TestExecute(t *testing.T) {
 
 func TestConvert(t *testing.T) {
 	convertToStr := convert(reflect.TypeOf(""))
-	convertToStrPtr := convert(reflect.PtrTo(reflect.TypeOf("")))
 	t.Run("convert to string", func(t *testing.T) {
 		s := "test"
 		v, err := convertToStr(reflect.ValueOf(&s), nil)
@@ -205,39 +204,8 @@ func TestConvert(t *testing.T) {
 			t.Fatalf("expect %s but got %s", expect, got)
 		}
 	})
-	t.Run("convert to string pointer", func(t *testing.T) {
-		v, err := convertToStrPtr(reflect.ValueOf("test"), nil)
-		if err != nil {
-			t.Fatalf("failed to convert: %s", err)
-		}
-		if got, expect := v.Type().Kind(), reflect.Ptr; got != expect {
-			t.Fatalf("expect %s but got %s", expect, got)
-		}
-		if got, expect := v.Type().Elem().Kind(), reflect.String; got != expect {
-			t.Fatalf("expect %s but got %s", expect, got)
-		}
-	})
-	t.Run("can't convert", func(t *testing.T) {
-		v, err := convertToStrPtr(reflect.ValueOf(1), nil)
-		if err != nil {
-			t.Fatalf("failed to convert: %s", err)
-		}
-		if got, expect := v.Type().Kind(), reflect.Int; got != expect {
-			t.Fatalf("expect %s but got %s", expect, got)
-		}
-	})
-	t.Run("invalid value", func(t *testing.T) {
-		invalid := reflect.ValueOf(nil)
-		v, err := convertToStrPtr(invalid, nil)
-		if err != nil {
-			t.Fatalf("failed to convert: %s", err)
-		}
-		if got, expect := v, invalid; got != expect {
-			t.Fatalf("expect %s but got %s", expect, got)
-		}
-	})
 	t.Run("error", func(t *testing.T) {
-		_, err := convertToStrPtr(reflect.Value{}, errors.New("execute() failed"))
+		_, err := convertToStr(reflect.Value{}, errors.New("execute() failed"))
 		if err == nil {
 			t.Fatal("no error")
 		}

--- a/template/lookup.go
+++ b/template/lookup.go
@@ -17,7 +17,11 @@ func lookup(node ast.Node, data interface{}) (interface{}, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create query from AST")
 	}
-	return q.Extract(data)
+	v, err := q.Extract(data)
+	if err != nil {
+		return nil, err
+	}
+	return Execute(v, data)
 }
 
 func newQuery() *query.Query {


### PR DESCRIPTION
Left arrow function arguments must be a YAML string. The variables included in the argument are marshaled to YAML string once and concatenated with other strings.

```yaml
# data:
#   a: 1
#   b: 2
{{laf <-}}:
  - '{{data}}'
```
```yaml
# marshal data to YAML string
{{laf <-}}:
  - a: 1
b: 2
```

The marshaled YAML string must be concatenated with proper indents to keep its structure.

```yaml
# add indents to keep structure
{{laf <-}}:
  - a: 1
    b: 2
```

fix #124