### PR TITLE
fix(template): marshal variables to YAML in LAF arguments

### DIFF
--- a/template/execute.go
+++ b/template/execute.go
@@ -45,6 +45,8 @@ func structFieldName(field reflect.StructField) string {
 func execute(in reflect.Value, data interface{}) (reflect.Value, error) {
 	v := reflectutil.Elem(in)
 	switch v.Kind() {
+	case reflect.Invalid:
+		return in, nil
 	case reflect.Map:
 		for _, k := range v.MapKeys() {
 			e := v.MapIndex(k)
@@ -117,7 +119,7 @@ func execute(in reflect.Value, data interface{}) (reflect.Value, error) {
 	}
 
 	// keep the original type as much as possible
-	if in.IsValid() {
+	if in.IsValid() && v.IsValid() {
 		if converted, err := convert(in.Type())(v, nil); err == nil {
 			v = converted
 		}

--- a/template/execute_test.go
+++ b/template/execute_test.go
@@ -140,6 +140,10 @@ func TestExecute(t *testing.T) {
 				},
 			},
 		},
+		"zero struct": {
+			in:       s{},
+			expected: s{},
+		},
 		"struct": {
 			in: s{
 				Str:        tmpl,


### PR DESCRIPTION
Quote number strings (e.g., "123") to avoid interpreting as not string.