### PR TITLE
add workaround to avoid the bug of Go 1.17

### DIFF
--- a/.github/workflows/generate-credits.yml
+++ b/.github/workflows/generate-credits.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: 1.16.5
+        go-version: 1.17.x
     - name: Generate token # required to trigger actions on the commit
       id: generate_token
       uses: tibdex/github-app-token@v1.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: 1.16.5
+        go-version: 1.17.x
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: 1.16
+        go-version: 1.17.x
     - name: Checkout code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: [1.16.x]
+        go-version: [1.16.x, 1.17.x]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
@@ -23,7 +23,7 @@ jobs:
     - name: Test
       run: make test/ci
     - name: Upload coverage
-      if: matrix.os == 'ubuntu-latest' && startsWith(matrix.go-version, '1.16')
+      if: matrix.os == 'ubuntu-latest' && startsWith(matrix.go-version, '1.17')
       uses: codecov/codecov-action@v2
       with:
         file: ./coverage.out

--- a/protocol/grpc/workaround_go1.17.go
+++ b/protocol/grpc/workaround_go1.17.go
@@ -1,0 +1,15 @@
+//go:build go1.17
+// +build go1.17
+
+package grpc
+
+import (
+	"google.golang.org/grpc"
+)
+
+func init() {
+	// This function call tells the Go compiler that the interface grpc.DialOption will be used.
+	// It prevents the bug that fails to method call by deleting references by the linker.
+	// ref. https://github.com/zoncoen/scenarigo/issues/136
+	grpc.Dial("", grpc.WithInsecure())
+}


### PR DESCRIPTION
Go 1.17 may have a linker bug.
When loading plugins that have `grpc.Dial()` function call, the Go linker raises the error `fatal error: unreachable method called. linker bug?`.
This PR adds a workaround to avoid the bug.

ref. https://github.com/zoncoen/scenarigo/issues/136