### PR TITLE
feat(template): allow writing left arrow function call in map syntax

### DIFF
--- a/mock/protocol/http/handler.go
+++ b/mock/protocol/http/handler.go
@@ -2,19 +2,28 @@ package http
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"reflect"
 	"strconv"
 
-	"github.com/zoncoen/scenarigo/logger"
+	"github.com/goccy/go-yaml"
+
+	"github.com/zoncoen/scenarigo/assert"
+	"github.com/zoncoen/scenarigo/context"
+	"github.com/zoncoen/scenarigo/errors"
+	"github.com/zoncoen/scenarigo/internal/assertutil"
 	"github.com/zoncoen/scenarigo/internal/reflectutil"
+	"github.com/zoncoen/scenarigo/logger"
 	"github.com/zoncoen/scenarigo/mock/protocol"
 	httpprotocol "github.com/zoncoen/scenarigo/protocol/http"
 	"github.com/zoncoen/scenarigo/protocol/http/marshaler"
+	"github.com/zoncoen/scenarigo/protocol/http/unmarshaler"
 )
 
 // NewHandler returns a handler sending mock responses.
 func NewHandler(iter *protocol.MockIterator, l logger.Logger) http.Handler {
+	ctx := context.New(nil)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mock, err := iter.Next()
 		if err != nil {
@@ -26,10 +35,65 @@ func NewHandler(iter *protocol.MockIterator, l logger.Logger) http.Handler {
 			writeError(w, err, l)
 			return
 		}
-		var resp HTTPResponse
-		if mock.Response.Unmarshal(&resp); err != nil {
-			writeError(w, err, l)
+
+		var e expect
+		if err := mock.Expect.Unmarshal(&e); err != nil {
+			writeError(w, fmt.Errorf("failed to unmarshal expect: %w", err), l)
 			return
+		}
+		assertion, err := e.build(ctx)
+		if err != nil {
+			writeError(w, fmt.Errorf("failed to build assertion: %w", err), l)
+			return
+		}
+
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			writeError(w, fmt.Errorf("failed to read request body: %w", err), l)
+			return
+		}
+		var body interface{}
+		if len(b) > 0 {
+			mt := r.Header.Get("Content-Type")
+			if mt == "" {
+				mt = "application/json"
+				r.Header.Set("Content-Type", mt)
+			}
+			if err := unmarshaler.Get(mt).Unmarshal(b, &body); err != nil {
+				writeError(w, fmt.Errorf("failed to unmarshal request body: %w", err), l)
+				return
+			}
+		}
+		newCtx := ctx.WithRequest(map[string]interface{}{
+			"header": r.Header,
+			"body":   body,
+		})
+
+		if err := assertion.Assert(&request{
+			path:   r.URL.Path,
+			header: r.Header,
+			body:   body,
+		}); err != nil {
+			writeError(w, fmt.Errorf("assertion error: %w", err), l)
+			return
+		}
+
+		var resp HTTPResponse
+		if err := mock.Response.Unmarshal(&resp); err != nil {
+			writeError(w, fmt.Errorf("failed to unmarshal response: %w", err), l)
+			return
+		}
+
+		v, err := newCtx.ExecuteTemplate(resp)
+		if err != nil {
+			writeError(w, fmt.Errorf("failed to execute template of response body: %w", err), l)
+			return
+		}
+		if r, ok := v.(HTTPResponse); !ok {
+			writeError(w, fmt.Errorf("failed to execute template of response body: %w", err), l)
+			return
+		} else {
+			resp = r
 		}
 		if err := resp.Write(w); err != nil {
 			l.Error(err, "failed to write response")
@@ -42,6 +106,56 @@ func writeError(w http.ResponseWriter, err error, l logger.Logger) {
 	w.WriteHeader(http.StatusInternalServerError)
 	w.Write([]byte(err.Error()))
 	l.Error(err, "internal server error")
+}
+
+type request struct {
+	path   string
+	header http.Header
+	body   interface{}
+}
+
+type expect struct {
+	Path   *string       `yaml:"path"`
+	Header yaml.MapSlice `yaml:"header"`
+	Body   interface{}   `yaml:"body"`
+}
+
+func (e *expect) build(ctx *context.Context) (assert.Assertion, error) {
+	var pathAssertion assert.Assertion = assert.AssertionFunc(func(_ interface{}) error {
+		return nil
+	})
+	if e.Path != nil {
+		expectPath, err := ctx.ExecuteTemplate(*e.Path)
+		if err != nil {
+			return nil, errors.WrapPathf(err, "path", "invalid expect path")
+		}
+		pathAssertion = assert.Build(expectPath)
+	}
+
+	headerAssertion, err := assertutil.BuildHeaderAssertion(ctx, e.Header)
+
+	expectBody, err := ctx.ExecuteTemplate(e.Body)
+	if err != nil {
+		return nil, errors.WrapPathf(err, "body", "invalid expect response")
+	}
+	assertion := assert.Build(expectBody)
+
+	return assert.AssertionFunc(func(v interface{}) error {
+		req, ok := v.(*request)
+		if !ok {
+			return errors.Errorf("expected request but got %T", v)
+		}
+		if err := pathAssertion.Assert(req.path); err != nil {
+			return errors.WithPath(err, "path")
+		}
+		if err := headerAssertion.Assert(req.header); err != nil {
+			return errors.WithPath(err, "header")
+		}
+		if err := assertion.Assert(req.body); err != nil {
+			return errors.WithPath(err, "body")
+		}
+		return nil
+	}), nil
 }
 
 // HTTPResponse represents an HTTP response.
@@ -93,7 +207,13 @@ func (resp *HTTPResponse) extract() (int, http.Header, []byte, error) {
 	if resp.Body == nil {
 		return status, header, nil, nil
 	}
-	body, err := marshaler.Get(header.Get("Content-Type")).Marshal(resp.Body)
+
+	mt := header.Get("Content-Type")
+	if mt == "" {
+		mt = "application/json"
+		header.Set("Content-Type", mt)
+	}
+	body, err := marshaler.Get(mt).Marshal(resp.Body)
 	if err != nil {
 		return 0, nil, nil, fmt.Errorf("failed to marshal response body: %w", err)
 	}

--- a/mock/protocol/http/testdata/http-expect.yaml
+++ b/mock/protocol/http/testdata/http-expect.yaml
@@ -1,0 +1,11 @@
+- protocol: http
+  expect:
+    path: /echo
+    header:
+      Content-Type: application/json
+    body:
+      message: '{{assert.notZero}}'
+  response:
+    code: 200
+    body:
+      message: '{{request.body.message}}'

--- a/template/execute.go
+++ b/template/execute.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/goccy/go-yaml"
+	"github.com/zoncoen/query-go"
 	"github.com/zoncoen/scenarigo/errors"
 	"github.com/zoncoen/scenarigo/internal/reflectutil"
 )
@@ -14,6 +15,7 @@ import (
 var (
 	yamlMapItemType  = reflect.TypeOf(yaml.MapItem{})
 	yamlMapSliceType = reflect.TypeOf(yaml.MapSlice{})
+	lazyFuncType     = reflect.TypeOf(lazyFunc{})
 )
 
 // Execute executes templates of i with data.
@@ -56,7 +58,27 @@ func execute(in reflect.Value, data interface{}) (reflect.Value, error) {
 				if err != nil {
 					return reflect.Value{}, errors.WithPath(err, keyStr)
 				}
-				x, err := convert(v.Type().Elem())(execute(e, data))
+				// left arrow function
+				if ke := reflectutil.Elem(key); ke.IsValid() && ke.Type() == lazyFuncType && ke.CanInterface() {
+					if len(v.MapKeys()) != 1 {
+						return reflect.Value{}, errors.New("invalid left arrow function call")
+					}
+					if !isNil(e) {
+						x, err := execute(e, data)
+						if err != nil {
+							return reflect.Value{}, errors.WithPath(err, keyStr)
+						}
+						e = x
+					}
+					f := ke.Interface().(lazyFunc)
+					res, err := executeLeftArrowFunction(f.f, e)
+					if err != nil {
+						return reflect.Value{}, fmt.Errorf("failed to execute left arrow function: %w", err)
+					}
+					v = res
+					continue
+				}
+				x, err := convert(e.Type())(execute(e, data))
 				if err != nil {
 					return reflect.Value{}, errors.WithPath(err, keyStr)
 				}
@@ -68,12 +90,44 @@ func execute(in reflect.Value, data interface{}) (reflect.Value, error) {
 		for i := 0; i < v.Len(); i++ {
 			e := v.Index(i)
 			if !isNil(e) {
-				x, err := convert(v.Type().Elem())(execute(e, data))
-				if err != nil {
-					if v.Type() != yamlMapSliceType {
-						err = errors.WithPath(err, fmt.Sprintf("[%d]", i))
+				if !e.CanSet() {
+					e = makePtr(e).Elem() // create pointer to enable to set values
+				}
+				if e.Type() == yamlMapItemType {
+					key := e.FieldByName("Key")
+					keyStr := fmt.Sprint(key.Interface())
+					value := e.FieldByName("Value")
+					if !isNil(key) {
+						k, err := execute(key, data)
+						if err != nil {
+							return reflect.Value{}, errors.WithPath(err, keyStr)
+						}
+						key = k
 					}
-					return reflect.Value{}, err
+					// left arrow function
+					if ke := reflectutil.Elem(key); ke.IsValid() && ke.Type() == lazyFuncType && ke.CanInterface() {
+						if v.Len() != 1 {
+							return reflect.Value{}, errors.New("invalid left arrow function call")
+						}
+						if !isNil(value) {
+							x, err := execute(value, data)
+							if err != nil {
+								return reflect.Value{}, errors.WithPath(err, keyStr)
+							}
+							value = x
+						}
+						f := ke.Interface().(lazyFunc)
+						res, err := executeLeftArrowFunction(f.f, value)
+						if err != nil {
+							return reflect.Value{}, fmt.Errorf("failed to execute left arrow function: %w", err)
+						}
+						v = res
+						continue
+					}
+				}
+				x, err := convert(e.Type())(execute(e, data))
+				if err != nil {
+					return reflect.Value{}, errors.WithQuery(err, query.New().Index(i))
 				}
 				e.Set(x)
 			}
@@ -82,40 +136,19 @@ func execute(in reflect.Value, data interface{}) (reflect.Value, error) {
 		if !v.CanSet() {
 			v = makePtr(v).Elem() // create pointer to enable to set values
 		}
-		switch v.Type() {
-		case yamlMapItemType:
-			key := v.FieldByName("Key")
-			keyStr := fmt.Sprint(key.Interface())
-			if !isNil(key) {
-				x, err := execute(key, data)
-				if err != nil {
-					return reflect.Value{}, errors.WithPath(err, keyStr)
-				}
-				key.Set(x)
+		for i := 0; i < v.NumField(); i++ {
+			if !token.IsExported(v.Type().Field(i).Name) {
+				continue // skip unexported field
 			}
-			value := v.FieldByName("Value")
-			if !isNil(value) {
-				x, err := execute(value, data)
-				if err != nil {
-					return reflect.Value{}, errors.WithPath(err, keyStr)
-				}
-				value.Set(x)
+			field := v.Field(i)
+			x, err := convert(field.Type())(execute(field, data))
+			if err != nil {
+				fieldName := structFieldName(v.Type().Field(i))
+				return reflect.Value{}, errors.WithPath(err, fieldName)
 			}
-		default:
-			for i := 0; i < v.NumField(); i++ {
-				if !token.IsExported(v.Type().Field(i).Name) {
-					continue // skip unexported field
-				}
-				field := v.Field(i)
-				x, err := convert(field.Type())(execute(field, data))
-				if err != nil {
-					fieldName := structFieldName(v.Type().Field(i))
-					return reflect.Value{}, errors.WithPath(err, fieldName)
-				}
-				if err := reflectutil.Set(field, x); err != nil {
-					fieldName := structFieldName(v.Type().Field(i))
-					return reflect.Value{}, errors.WithPath(err, fieldName)
-				}
+			if err := reflectutil.Set(field, x); err != nil {
+				fieldName := structFieldName(v.Type().Field(i))
+				return reflect.Value{}, errors.WithPath(err, fieldName)
 			}
 		}
 	case reflect.String:
@@ -129,6 +162,113 @@ func execute(in reflect.Value, data interface{}) (reflect.Value, error) {
 		}
 		v = reflect.ValueOf(x)
 	default:
+	}
+
+	// keep the original type as much as possible
+	if in.IsValid() && v.IsValid() {
+		if converted, err := convert(in.Type())(v, nil); err == nil {
+			v = converted
+		}
+		// keep the original address
+		if in.Type().Kind() == reflect.Ptr && v.Type().Kind() == reflect.Ptr {
+			if v.Elem().Type().AssignableTo(in.Elem().Type()) {
+				reflectutil.Set(in.Elem(), v.Elem())
+				v = in
+			}
+		}
+	}
+	return v, nil
+}
+
+func executeLeftArrowFunction(f Func, v reflect.Value) (reflect.Value, error) {
+	s := new(funcStash)
+	x, err := replaceFuncs(v, s)
+	if err != nil {
+		return reflect.Value{}, fmt.Errorf("failed to stash functions to marshal argument to YAML: %w", err)
+	}
+	b, err := yaml.Marshal(x.Interface())
+	if err != nil {
+		return reflect.Value{}, fmt.Errorf("failed to marshal argument to YAML: %w", err)
+	}
+	arg, err := f.UnmarshalArg(func(v interface{}) error {
+		if err := yaml.UnmarshalWithOptions(b, v, yaml.UseOrderedMap(), yaml.Strict()); err != nil {
+			return err
+		}
+
+		// Restore functions that are replaced into strings.
+		// See the "HACK" comment of *Template.executeParameterExpr method.
+		arg, err := Execute(v, s)
+		if err != nil {
+			return fmt.Errorf("failed to restore functions: %w", err)
+		}
+		// NOTE: Decode method ensures that v is a pointer.
+		rv := reflect.ValueOf(v).Elem()
+		ev, err := convert(rv.Type())(reflect.ValueOf(arg), nil)
+		if err != nil {
+			return err
+		}
+		rv.Set(ev)
+
+		return nil
+	})
+	if err != nil {
+		return reflect.Value{}, fmt.Errorf("failed to unmarshal argument: %w", err)
+	}
+	res, err := f.Exec(arg)
+	if err != nil {
+		return reflect.Value{}, fmt.Errorf("failed to execute function: %w", err)
+	}
+	return reflect.ValueOf(res), nil
+}
+
+func replaceFuncs(in reflect.Value, s *funcStash) (reflect.Value, error) {
+	v := reflectutil.Elem(in)
+
+	switch v.Kind() {
+	case reflect.Map:
+		for _, k := range v.MapKeys() {
+			e := v.MapIndex(k)
+			if !isNil(e) {
+				x, err := replaceFuncs(e, s)
+				if err != nil {
+					return reflect.Value{}, err
+				}
+				v.SetMapIndex(k, x)
+			}
+		}
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			e := v.Index(i)
+			if !isNil(e) {
+				x, err := replaceFuncs(e, s)
+				if err != nil {
+					return reflect.Value{}, err
+				}
+				e.Set(x)
+			}
+		}
+	case reflect.Struct:
+		if !v.CanSet() {
+			v = makePtr(v).Elem() // create pointer to enable to set values
+		}
+		for i := 0; i < v.NumField(); i++ {
+			if !token.IsExported(v.Type().Field(i).Name) {
+				continue // skip unexported field
+			}
+			field := v.Field(i)
+			x, err := replaceFuncs(field, s)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			if err := reflectutil.Set(field, x); err != nil {
+				fieldName := structFieldName(v.Type().Field(i))
+				return reflect.Value{}, errors.WithPath(err, fieldName)
+			}
+		}
+	case reflect.Func:
+		return reflect.ValueOf(fmt.Sprintf("{{%s}}", s.save(v.Interface()))), nil
+	default:
+		return in, nil
 	}
 
 	// keep the original type as much as possible

--- a/template/execute_test.go
+++ b/template/execute_test.go
@@ -92,6 +92,14 @@ func TestExecute(t *testing.T) {
 				"env": {"test"},
 			},
 		},
+		"map with template key": {
+			in: map[string]string{
+				`{{"1"}}`: "one",
+			},
+			expected: map[string]string{
+				"1": "one",
+			},
+		},
 		"[]string": {
 			in:       []string{`{{"one"}}`, "two", `{{"three"}}`},
 			expected: []string{"one", "two", "three"},
@@ -114,6 +122,10 @@ func TestExecute(t *testing.T) {
 					Key:   "name",
 					Value: `{{"Bob"}}`,
 				},
+				yaml.MapItem{
+					Key:   "{{1}}",
+					Value: "one",
+				},
 			},
 			expected: yaml.MapSlice{
 				yaml.MapItem{
@@ -123,6 +135,24 @@ func TestExecute(t *testing.T) {
 				yaml.MapItem{
 					Key:   "name",
 					Value: "Bob",
+				},
+				yaml.MapItem{
+					Key:   1,
+					Value: "one",
+				},
+			},
+		},
+		"yaml.MapSlice (Key is nil)": {
+			in: yaml.MapSlice{
+				yaml.MapItem{
+					Key:   nil,
+					Value: "value",
+				},
+			},
+			expected: yaml.MapSlice{
+				yaml.MapItem{
+					Key:   nil,
+					Value: "value",
 				},
 			},
 		},

--- a/template/execute_test.go
+++ b/template/execute_test.go
@@ -211,6 +211,85 @@ func TestExecute(t *testing.T) {
 				"c": "test",
 			},
 		},
+		"left arrow function (map)": {
+			in: map[string]interface{}{
+				"{{echo <-}}": map[string]interface{}{
+					"message": map[string]interface{}{
+						"{{join <-}}": map[string]interface{}{
+							"prefix": "pre-",
+							"text": map[string]interface{}{
+								"{{call <-}}": map[string]interface{}{
+									"f":   "{{f}}",
+									"arg": "{{text}}",
+								},
+							},
+							"suffix": "-suf",
+						},
+					},
+				},
+			},
+			expected: "pre-test-suf",
+			vars: map[string]interface{}{
+				"echo": &echoFunc{},
+				"join": &joinFunc{},
+				"call": &callFunc{},
+				"f":    func(s string) string { return s },
+				"text": "test",
+			},
+		},
+		"left arrow function (yaml.MapSlice)": {
+			in: yaml.MapSlice{
+				yaml.MapItem{
+					Key: "{{echo <-}}",
+					Value: yaml.MapSlice{
+						yaml.MapItem{
+							Key: "message",
+							Value: yaml.MapSlice{
+								yaml.MapItem{
+									Key: "{{join <-}}",
+									Value: yaml.MapSlice{
+										yaml.MapItem{
+											Key:   "prefix",
+											Value: "pre-",
+										},
+										yaml.MapItem{
+											Key: "text",
+											Value: yaml.MapSlice{
+												yaml.MapItem{
+													Key: "{{call <-}}",
+													Value: yaml.MapSlice{
+														yaml.MapItem{
+															Key:   "f",
+															Value: "{{f}}",
+														},
+														yaml.MapItem{
+															Key:   "arg",
+															Value: "{{text}}",
+														},
+													},
+												},
+											},
+										},
+										yaml.MapItem{
+											Key:   "suffix",
+											Value: "-suf",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "pre-test-suf",
+			vars: map[string]interface{}{
+				"echo": &echoFunc{},
+				"join": &joinFunc{},
+				"call": &callFunc{},
+				"f":    func(s string) string { return s },
+				"text": "test",
+			},
+		},
 	}
 	for name, test := range tests {
 		test := test

--- a/template/parser/parser_test.go
+++ b/template/parser/parser_test.go
@@ -340,6 +340,22 @@ func TestParser_Parse(t *testing.T) {
 					Rdbrace: 10,
 				},
 			},
+			"YAML arg function without arg": {
+				src: "{{test <-}}",
+				expected: &ast.ParameterExpr{
+					Ldbrace: 1,
+					X: &ast.LeftArrowExpr{
+						Fun: &ast.Ident{
+							NamePos: 3,
+							Name:    "test",
+						},
+						Larrow:  8,
+						Rdbrace: 10,
+						Arg:     nil,
+					},
+					Rdbrace: 10,
+				},
+			},
 			"add": {
 				src: `{{"foo"+"-"+"1"}}`,
 				expected: &ast.ParameterExpr{

--- a/template/parser/scanner_test.go
+++ b/template/parser/scanner_test.go
@@ -85,6 +85,41 @@ func TestScanner_Scan(t *testing.T) {
 					},
 				},
 			},
+			`escape \`: {
+				src: `\\`,
+				expected: []result{
+					{
+						pos: 1,
+						tok: token.STRING,
+						lit: `\`,
+					},
+				},
+			},
+			`escape {`: {
+				src: `\{\{`,
+				expected: []result{
+					{
+						pos: 1,
+						tok: token.STRING,
+						lit: "{{",
+					},
+				},
+			},
+			`escape complex`: {
+				src: `{\{\\{{`,
+				expected: []result{
+					{
+						pos: 1,
+						tok: token.STRING,
+						lit: `{{\`,
+					},
+					{
+						pos: 6,
+						tok: token.LDBRACE,
+						lit: "{{",
+					},
+				},
+			},
 			"trailing {": {
 				src: "test {",
 				expected: []result{

--- a/template/parser/scanner_test.go
+++ b/template/parser/scanner_test.go
@@ -594,6 +594,31 @@ func TestScanner_Scan(t *testing.T) {
 					},
 				},
 			},
+			"YAML arg function without arg": {
+				src: "{{test <-}}",
+				expected: []result{
+					{
+						pos: 1,
+						tok: token.LDBRACE,
+						lit: "{{",
+					},
+					{
+						pos: 3,
+						tok: token.IDENT,
+						lit: "test",
+					},
+					{
+						pos: 8,
+						tok: token.LARROW,
+						lit: "<-",
+					},
+					{
+						pos: 10,
+						tok: token.RDBRACE,
+						lit: "}}",
+					},
+				},
+			},
 			"add": {
 				src: `{{"test"+"1"}}`,
 				expected: []result{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -185,7 +186,9 @@ func runMockServer(t *testing.T, filename string, ignoreMocksRemainError bool) f
 	if err := yaml.NewDecoder(f, yaml.Strict()).Decode(&config); err != nil {
 		t.Fatal(err)
 	}
-	srv, err := mock.NewServer(&config, logger.NewNopLogger())
+	var b bytes.Buffer
+	l := logger.NewLogger(log.New(&b, "", log.LstdFlags), logger.LogLevelAll)
+	srv, err := mock.NewServer(&config, l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,6 +224,9 @@ func runMockServer(t *testing.T, filename string, ignoreMocksRemainError bool) f
 		}
 		if err := <-ch; err != nil {
 			t.Fatalf("failed to start: %s", err)
+		}
+		if t.Failed() {
+			t.Log(b.String())
 		}
 	}
 }

--- a/test/e2e/testdata/testcases/left-arrow-function.yaml
+++ b/test/e2e/testdata/testcases/left-arrow-function.yaml
@@ -1,0 +1,10 @@
+title: retry
+scenarios:
+- filename: left-arrow-function.yaml
+  mocks: left-arrow-function.yaml
+  success: true
+  output:
+    stdout: left-arrow-function.txt
+  verbose: false
+  plugins:
+  - complex.so

--- a/test/e2e/testdata/testcases/mocks/left-arrow-function.yaml
+++ b/test/e2e/testdata/testcases/mocks/left-arrow-function.yaml
@@ -1,0 +1,10 @@
+mocks:
+- protocol: http
+  expect:
+    path: /echo
+    body:
+      message: preout-prein-test-sufin-sufout
+  response:
+    code: 200
+    body:
+      message: '{{request.body.message}}'

--- a/test/e2e/testdata/testcases/scenarios/left-arrow-function.yaml
+++ b/test/e2e/testdata/testcases/scenarios/left-arrow-function.yaml
@@ -1,0 +1,27 @@
+title: left arrow function
+plugins:
+  complex: complex.so
+vars:
+  text: test
+steps:
+- title: POST /echo
+  vars:
+    message:
+      '{{plugins.complex.Join <-}}':
+        prefix: preout-
+        text:
+          '{{plugins.complex.Join <-}}':
+            prefix: prein-
+            text: '{{vars.text}}'
+            suffix: -sufin
+        suffix: -sufout
+  protocol: http
+  request:
+    method: POST
+    url: "http://{{env.TEST_HTTP_ADDR}}/echo"
+    body:
+      message: "{{vars.message}}"
+  expect:
+    code: 200
+    body:
+      message: preout-prein-test-sufin-sufout

--- a/test/e2e/testdata/testcases/stdout/left-arrow-function.txt
+++ b/test/e2e/testdata/testcases/stdout/left-arrow-function.txt
@@ -1,0 +1,1 @@
+ok  	testdata/testcases/scenarios/left-arrow-function.yaml	0.000s


### PR DESCRIPTION
It is very annoying for users to write complicated left arrow function calls because they have to write in a single string literal.

```yaml
- title: POST /echo
  vars:
    message: |-
      {{plugins.complex.Join <-}}:
        prefix: preout-
        text: |-
          {{plugins.complex.Join <-}}:
            prefix: prein-
            text: '{{vars.text}}'
            suffix: -sufin
        suffix: -sufout
```

This PR enables writing left arrow function call as mapping.

```yaml
- title: POST /echo
  vars:
    message:
      '{{plugins.complex.Join <-}}':
        prefix: preout-
        text:
          '{{plugins.complex.Join <-}}':
            prefix: prein-
            text: '{{vars.text}}'
            suffix: -sufin
        suffix: -sufout
```