### PR TITLE
feat(template): allow functions to return an error

### DIFF
--- a/internal/reflectutil/type.go
+++ b/internal/reflectutil/type.go
@@ -1,0 +1,7 @@
+package reflectutil
+
+import "reflect"
+
+var (
+	TypeError = reflect.TypeOf((*error)(nil)).Elem()
+)

--- a/protocol/grpc/expect_test.go
+++ b/protocol/grpc/expect_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/zoncoen/scenarigo/context"
+	"github.com/zoncoen/scenarigo/internal/reflectutil"
 	"github.com/zoncoen/scenarigo/testdata/gen/pb/test"
 )
 
@@ -28,7 +29,7 @@ func TestExpect_Build(t *testing.T) {
 				v: response{
 					rvalues: []reflect.Value{
 						reflect.ValueOf(&test.EchoResponse{}),
-						reflect.Zero(reflect.TypeOf((*error)(nil)).Elem()),
+						reflect.Zero(reflectutil.TypeError),
 					},
 				},
 			},
@@ -85,7 +86,7 @@ func TestExpect_Build(t *testing.T) {
 							MessageId:   "1",
 							MessageBody: "hello",
 						}),
-						reflect.Zero(reflect.TypeOf((*error)(nil)).Elem()),
+						reflect.Zero(reflectutil.TypeError),
 					},
 				},
 			},
@@ -107,7 +108,7 @@ func TestExpect_Build(t *testing.T) {
 					},
 					rvalues: []reflect.Value{
 						reflect.ValueOf(&test.EchoResponse{}),
-						reflect.Zero(reflect.TypeOf((*error)(nil)).Elem()),
+						reflect.Zero(reflectutil.TypeError),
 					},
 				},
 			},
@@ -129,7 +130,7 @@ func TestExpect_Build(t *testing.T) {
 					},
 					rvalues: []reflect.Value{
 						reflect.ValueOf(&test.EchoResponse{}),
-						reflect.Zero(reflect.TypeOf((*error)(nil)).Elem()),
+						reflect.Zero(reflectutil.TypeError),
 					},
 				},
 			},
@@ -211,7 +212,7 @@ func TestExpect_Build(t *testing.T) {
 							MessageId:   "1",
 							MessageBody: "hello",
 						}),
-						reflect.Zero(reflect.TypeOf((*error)(nil)).Elem()),
+						reflect.Zero(reflectutil.TypeError),
 					},
 				},
 			},
@@ -355,7 +356,7 @@ func TestExpect_Build(t *testing.T) {
 							MessageId:   "1",
 							MessageBody: "hell",
 						}),
-						reflect.Zero(reflect.TypeOf((*error)(nil)).Elem()),
+						reflect.Zero(reflectutil.TypeError),
 					},
 				},
 				expectAssertError: true,
@@ -378,7 +379,7 @@ func TestExpect_Build(t *testing.T) {
 					},
 					rvalues: []reflect.Value{
 						reflect.ValueOf(&test.EchoResponse{}),
-						reflect.Zero(reflect.TypeOf((*error)(nil)).Elem()),
+						reflect.Zero(reflectutil.TypeError),
 					},
 				},
 				expectAssertError: true,
@@ -401,7 +402,7 @@ func TestExpect_Build(t *testing.T) {
 					},
 					rvalues: []reflect.Value{
 						reflect.ValueOf(&test.EchoResponse{}),
-						reflect.Zero(reflect.TypeOf((*error)(nil)).Elem()),
+						reflect.Zero(reflectutil.TypeError),
 					},
 				},
 				expectAssertError: true,
@@ -424,7 +425,7 @@ func TestExpect_Build(t *testing.T) {
 					},
 					rvalues: []reflect.Value{
 						reflect.ValueOf(&test.EchoResponse{}),
-						reflect.Zero(reflect.TypeOf((*error)(nil)).Elem()),
+						reflect.Zero(reflectutil.TypeError),
 					},
 				},
 				expectAssertError: true,
@@ -447,7 +448,7 @@ func TestExpect_Build(t *testing.T) {
 					},
 					rvalues: []reflect.Value{
 						reflect.ValueOf(&test.EchoResponse{}),
-						reflect.Zero(reflect.TypeOf((*error)(nil)).Elem()),
+						reflect.Zero(reflectutil.TypeError),
 					},
 				},
 				expectAssertError: true,
@@ -470,7 +471,7 @@ func TestExpect_Build(t *testing.T) {
 					},
 					rvalues: []reflect.Value{
 						reflect.ValueOf(&test.EchoResponse{}),
-						reflect.Zero(reflect.TypeOf((*error)(nil)).Elem()),
+						reflect.Zero(reflectutil.TypeError),
 					},
 				},
 				expectAssertError: true,

--- a/protocol/grpc/request.go
+++ b/protocol/grpc/request.go
@@ -189,7 +189,7 @@ func validateMethod(method reflect.Value) error {
 	if t := mt.Out(0); !t.Implements(typeMessage) {
 		return errors.Errorf("first return value must be proto.Message but got %s", t.String())
 	}
-	if t := mt.Out(1); !t.Implements(typeError) {
+	if t := mt.Out(1); !t.Implements(reflectutil.TypeError) {
 		return errors.Errorf("second return value must be error but got %s", t.String())
 	}
 

--- a/protocol/grpc/type.go
+++ b/protocol/grpc/type.go
@@ -12,5 +12,4 @@ var (
 	typeContext  = reflect.TypeOf((*context.Context)(nil)).Elem()
 	typeMessage  = reflect.TypeOf((*proto.Message)(nil)).Elem()
 	typeCallOpts = reflect.TypeOf([]grpc.CallOption(nil))
-	typeError    = reflect.TypeOf((*error)(nil)).Elem()
 )


### PR DESCRIPTION
This PR enables template functions to return errors.

### example

```go
tmpl, _ := template.New(`{{fn()}}`)
_, err := tmpl.Execute(map[string]interface{}{
    "fn": func() (string, error) { return "", errors.New("fn() error") },
})
fmt.Println(err)
```

=> `failed to execute: {{fn()}}: fn() error`