### PR TITLE
chore(release): remove go1.17

### DIFF
--- a/scripts/cross-build/build-matrix/main.go
+++ b/scripts/cross-build/build-matrix/main.go
@@ -14,13 +14,11 @@ import (
 	"github.com/zoncoen/scenarigo/scripts/cross-build/gen"
 )
 
-var (
-	go117 *semver.Version
-)
+var go118 *semver.Version
 
 func init() {
 	var err error
-	go117, err = semver.NewVersion("1.17.0")
+	go118, err = semver.NewVersion("1.18.0")
 	if err != nil {
 		panic(err)
 	}
@@ -71,7 +69,7 @@ func getVers(token string) ([]string, error) {
 		if err != nil {
 			continue
 		}
-		if !v.LessThan(go117) {
+		if !v.LessThan(go118) {
 			vers = append(vers, v.Original())
 		}
 	}


### PR DESCRIPTION
Go1.19 has been released.

> Each major Go release is supported until there are two newer major releases.

https://go.dev/doc/devel/release#policy

```sh
$ go run ./build-matrix/main.go
["1.19.1","1.18.6","1.19","1.18.5","1.18.4","1.18.3","1.18.2","1.18.1","1.18"]
```