### PR TITLE
fix: don't bind vars if included scenario failed

### DIFF
--- a/step.go
+++ b/step.go
@@ -53,6 +53,9 @@ func runStep(ctx *context.Context, scenario *schema.Scenario, s *schema.Step, st
 		ctx.Reporter().Run(testName, func(rptr reporter.Reporter) {
 			ctx = RunScenario(ctx.WithReporter(rptr).WithNode(scenarios[0].Node), scenarios[0])
 		})
+		if ctx.Reporter().Failed() {
+			ctx.Reporter().FailNow()
+		}
 
 		// back node to current node
 		ctx = ctx.WithNode(currentNode)

--- a/test/e2e/testdata/testcases/include.yaml
+++ b/test/e2e/testdata/testcases/include.yaml
@@ -1,0 +1,14 @@
+title: include
+scenarios:
+- filename: include/scenario.yaml
+  mocks: include/success.yaml
+  success: true
+  output:
+    stdout: include/success.txt
+  verbose: false
+- filename: include/scenario.yaml
+  mocks: include/failure.yaml
+  success: false
+  output:
+    stdout: include/failure.txt
+  verbose: false

--- a/test/e2e/testdata/testcases/mocks/include/failure.yaml
+++ b/test/e2e/testdata/testcases/mocks/include/failure.yaml
@@ -1,0 +1,4 @@
+mocks:
+- protocol: http
+  response:
+    code: 400

--- a/test/e2e/testdata/testcases/mocks/include/success.yaml
+++ b/test/e2e/testdata/testcases/mocks/include/success.yaml
@@ -1,0 +1,6 @@
+mocks:
+- protocol: http
+  response:
+    code: 200
+    body:
+      message: aaa

--- a/test/e2e/testdata/testcases/scenarios/include/included.yaml
+++ b/test/e2e/testdata/testcases/scenarios/include/included.yaml
@@ -1,0 +1,14 @@
+---
+title: included scenario
+steps:
+- protocol: http
+  request:
+    method: GET
+    url: "http://{{env.TEST_HTTP_ADDR}}/echo"
+  expect:
+    code: OK
+    body:
+      message: aaa
+  bind:
+    vars:
+      message: '{{response.message}}'

--- a/test/e2e/testdata/testcases/scenarios/include/scenario.yaml
+++ b/test/e2e/testdata/testcases/scenarios/include/scenario.yaml
@@ -1,0 +1,8 @@
+---
+title: included scenario fails
+steps:
+- title: include
+  include: './included.yaml'
+  bind:
+    vars:
+      message: '{{vars.message}}'

--- a/test/e2e/testdata/testcases/stdout/include/failure.txt
+++ b/test/e2e/testdata/testcases/stdout/include/failure.txt
@@ -1,0 +1,25 @@
+--- FAIL: testdata/testcases/scenarios/include/scenario.yaml (0.00s)
+    --- FAIL: testdata/testcases/scenarios/include/scenario.yaml/included_scenario_fails (0.00s)
+        --- FAIL: testdata/testcases/scenarios/include/scenario.yaml/included_scenario_fails/include (0.00s)
+            --- FAIL: testdata/testcases/scenarios/include/scenario.yaml/included_scenario_fails/include/included.yaml (0.00s)
+                --- FAIL: testdata/testcases/scenarios/include/scenario.yaml/included_scenario_fails/include/included.yaml/ (0.00s)
+                        [0] send request
+                        request:
+                          method: GET
+                          url: http://[::]:12345/echo
+                          header:
+                            User-Agent:
+                            - scenarigo/v1.0.0
+                        elapsed time: 0.000000 sec
+                           6 |     method: GET
+                           7 |     url: "http://{{env.TEST_HTTP_ADDR}}/echo"
+                           8 |   expect:
+                        >  9 |     code: OK
+                                         ^
+                          10 |     body:
+                          11 |       message: aaa
+                          12 |   bind:
+                        expected OK but got Bad Request
+FAIL
+FAIL	testdata/testcases/scenarios/include/scenario.yaml	0.000s
+FAIL

--- a/test/e2e/testdata/testcases/stdout/include/success.txt
+++ b/test/e2e/testdata/testcases/stdout/include/success.txt
@@ -1,0 +1,1 @@
+ok  	testdata/testcases/scenarios/include/scenario.yaml	0.000s


### PR DESCRIPTION
Stop outputting unnecessary logs to make isolating the root cause easier.

## example

### before
```
--- FAIL: testdata/testcases/scenarios/include/scenario.yaml (0.00s)
    --- FAIL: testdata/testcases/scenarios/include/scenario.yaml/included_scenario_fails (0.00s)
        --- FAIL: testdata/testcases/scenarios/include/scenario.yaml/included_scenario_fails/include (0.00s)
            --- FAIL: testdata/testcases/scenarios/include/scenario.yaml/included_scenario_fails/include/included.yaml (0.00s)
                       5 |   include: './included.yaml'
                       6 |   bind:
                       7 |     vars:
                    >  8 |       message: '{{vars.message}}'
                                          ^
                    invalid bind: failed to execute: {{vars.message}}: ".vars.message" not found
                --- FAIL: testdata/testcases/scenarios/include/scenario.yaml/included_scenario_fails/include/included.yaml/ (0.00s)
                        [0] send request
                        request:
                          method: GET
                          url: http://[::]:12345/echo
                          header:
                            User-Agent:
                            - scenarigo/v1.0.0
                        elapsed time: 0.000000 sec
                           6 |     method: GET
                           7 |     url: "http://{{env.TEST_HTTP_ADDR}}/echo"
                           8 |   expect:
                        >  9 |     code: OK
                                         ^
                          10 |     body:
                          11 |       message: aaa
                          12 |   bind:
                        expected OK but got Bad Request
FAIL
FAIL    testdata/testcases/scenarios/include/scenario.yaml      0.000s
FAIL
```

### after

```
--- FAIL: testdata/testcases/scenarios/include/scenario.yaml (0.00s)
    --- FAIL: testdata/testcases/scenarios/include/scenario.yaml/included_scenario_fails (0.00s)
        --- FAIL: testdata/testcases/scenarios/include/scenario.yaml/included_scenario_fails/include (0.00s)
            --- FAIL: testdata/testcases/scenarios/include/scenario.yaml/included_scenario_fails/include/included.yaml (0.00s)
                --- FAIL: testdata/testcases/scenarios/include/scenario.yaml/included_scenario_fails/include/included.yaml/ (0.00s)
                        [0] send request
                        request:
                          method: GET
                          url: http://[::]:12345/echo
                          header:
                            User-Agent:
                            - scenarigo/v1.0.0
                        elapsed time: 0.000000 sec
                           6 |     method: GET
                           7 |     url: "http://{{env.TEST_HTTP_ADDR}}/echo"
                           8 |   expect:
                        >  9 |     code: OK
                                         ^
                          10 |     body:
                          11 |       message: aaa
                          12 |   bind:
                        expected OK but got Bad Request
FAIL
FAIL    testdata/testcases/scenarios/include/scenario.yaml      0.000s
FAIL
```