### PR TITLE
chore(deps): bump goccy/go-yaml from v1.9.8 to v1.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/fatih/color v1.14.1
-	github.com/goccy/go-yaml v1.9.8
+	github.com/goccy/go-yaml v1.10.0
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
-github.com/goccy/go-yaml v1.9.8 h1:5gMyLUeU1/6zl+WFfR1hN7D2kf+1/eRGa7DFtToiBvQ=
-github.com/goccy/go-yaml v1.9.8/go.mod h1:JubOolP3gh0HpiBc4BLRD4YmjEjHAmIIB2aaXKkTfoE=
+github.com/goccy/go-yaml v1.10.0 h1:rBi+5HGuznOxx0JZ+60LDY85gc0dyIJCIMvsMJTKSKQ=
+github.com/goccy/go-yaml v1.10.0/go.mod h1:h/18Lr6oSQ3mvmqFoWmQ47KChOgpfHpTyIHl3yVmpiY=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=

--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -22,12 +22,17 @@ func TestLoadConfig(t *testing.T) {
 			"with comment": {
 				path: "testdata/config/valid-with-comment.yaml",
 				expectComments: yaml.CommentMap{
-					"$.schemaVersion": &yaml.Comment{
-						Texts:    []string{" comment1", " comment2"},
-						Position: yaml.CommentHeadPosition,
+					"$.schemaVersion": []*yaml.Comment{
+						{
+							Texts:    []string{" comment1", " comment2"},
+							Position: yaml.CommentHeadPosition,
+						},
 					},
-					"$.plugins.'remote-with-version.so'.src": &yaml.Comment{
-						Texts: []string{" comment3"},
+					"$.plugins.'remote-with-version.so'.src": []*yaml.Comment{
+						{
+							Texts:    []string{" comment3"},
+							Position: yaml.CommentLinePosition,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
SSIA

[changelog](https://github.com/goccy/go-yaml/compare/v1.9.8...v1.10.0)