### PR TITLE
fix(schema): add a workaround to avoid failing to load scenarios

### DIFF
--- a/runner_test.go
+++ b/runner_test.go
@@ -493,25 +493,6 @@ func TestRunner_Dump(t *testing.T) {
 					},
 				},
 			},
-			"disable ytt integration": {
-				config: &schema.Config{
-					Scenarios: []string{"testdata/ytt.yaml"},
-				},
-				expect: `schemaVersion: scenario/v1
-title: echo
-vars:
-  message: null
-steps:
-- title: POST /say
-  protocol: http
-  request:
-    body:
-      message: "{{vars.message}}"
-  expect:
-    body:
-      message: "{{request.message}}"
-`,
-			},
 			"enable ytt integration": {
 				config: &schema.Config{
 					Scenarios: []string{"testdata/ytt.yaml"},
@@ -527,25 +508,6 @@ steps:
 title: echo
 vars:
   message: hello
-steps:
-- title: POST /say
-  protocol: http
-  request:
-    body:
-      message: "{{vars.message}}"
-  expect:
-    body:
-      message: "{{request.message}}"
-`,
-			},
-			"invalid but disable ytt integration": {
-				config: &schema.Config{
-					Scenarios: []string{"testdata/ytt_invalid.yaml"},
-				},
-				expect: `schemaVersion: scenario/v1
-title: echo
-vars:
-  message: null
 steps:
 - title: POST /say
   protocol: http
@@ -598,6 +560,36 @@ steps:
 				expect: fmt.Sprintf(`failed to load scenarios: ytt failed:
 - undefined: msg
     %s/testdata/ytt_invalid.yaml:4 |   message: #@ msg`, wd),
+			},
+			"disable ytt integration": {
+				config: &schema.Config{
+					Scenarios: []string{"testdata/ytt.yaml"},
+				},
+				expect: `failed to load scenarios: failed to decode YAML: [5:3] string was used where mapping is expected
+       2 | schemaVersion: scenario/v1
+       3 | title: echo
+       4 | vars:
+    >  5 |   message #@ msg: null
+             ^
+       6 | steps:
+       7 | - title: POST /say
+       8 |   protocol: http
+       9 |  `,
+			},
+			"invalid but disable ytt integration": {
+				config: &schema.Config{
+					Scenarios: []string{"testdata/ytt_invalid.yaml"},
+				},
+				expect: `failed to load scenarios: failed to decode YAML: [4:3] string was used where mapping is expected
+       1 | schemaVersion: scenario/v1
+       2 | title: echo
+       3 | vars:
+    >  4 |   message #@ msg: null
+             ^
+       5 | steps:
+       6 | - title: POST /say
+       7 |   protocol: http
+       8 |  `,
 			},
 		}
 		for name, test := range tests {

--- a/schema/load.go
+++ b/schema/load.go
@@ -1,11 +1,11 @@
 package schema
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/goccy/go-yaml"
@@ -180,19 +180,41 @@ func findAllfiles(paths ...string) ([]string, error) {
 }
 
 func loadScenariosFromFileAST(f *ast.File) ([]*Scenario, error) {
-	var buf bytes.Buffer
-	dec := yaml.NewDecoder(&buf, yaml.UseOrderedMap(), yaml.Strict())
+	// workaround to avoid the issue #304
+	r := strings.NewReader(f.String())
+	dec := yaml.NewDecoder(r, yaml.UseOrderedMap(), yaml.Strict())
 	var scenarios []*Scenario
-	for _, doc := range f.Docs {
+	var i int
+	for {
 		var s Scenario
-		if err := dec.DecodeFromNode(doc.Body, &s); err != nil {
+		if err := dec.Decode(&s); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
 			return nil, fmt.Errorf("failed to decode YAML: %w", err)
 		}
 		s.filepath = f.Name
-		s.Node = doc.Body
+		if i < len(f.Docs) {
+			s.Node = f.Docs[i].Body
+		}
 		scenarios = append(scenarios, &s)
+		i++
 	}
 	return scenarios, nil
+
+	// var buf bytes.Buffer
+	// dec := yaml.NewDecoder(&buf, yaml.UseOrderedMap(), yaml.Strict())
+	// var scenarios []*Scenario
+	// for _, doc := range f.Docs {
+	// 	var s Scenario
+	// 	if err := dec.DecodeFromNode(doc.Body, &s); err != nil {
+	// 		return nil, fmt.Errorf("failed to decode YAML: %w", err)
+	// 	}
+	// 	s.filepath = f.Name
+	// 	s.Node = doc.Body
+	// 	scenarios = append(scenarios, &s)
+	// }
+	// return scenarios, nil
 }
 
 type loadOption struct {


### PR DESCRIPTION
[`(*Decoder).DecodeFromNode`](https://pkg.go.dev/github.com/goccy/go-yaml@v1.11.0#Decoder.DecodeFromNode) seems to have a bug. We must convert the AST Nodes to a string once and then decode it to avoid the issue.

resolve #304 