### PR TITLE
chore: fix goreleaser config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,12 @@ crossbuild:
 	@rm -rf ./dist ./assets
 	@ls ./tmp/
 
+.PHONY: crossbuild/test
+crossbuild/test:
+	@rm -rf ./dist
+	@SNAPSHOT=true GO_VERSION=$$(go version | perl -ape '$$_ = $$F[2]; s/go(.+)/$$1/') make build/ci
+	@ls ./dist
+
 .PHONY: build/ci
 build/ci:
 	@rm -rf assets

--- a/scripts/cross-build/cross-build/templates/goreleaser.yml.tmpl
+++ b/scripts/cross-build/cross-build/templates/goreleaser.yml.tmpl
@@ -41,13 +41,14 @@ builds:
     - amd64
 
 archives:
-- name_template: "{{ .ProjectName  }}_v{{ .Version }}_go<< .GoVersion >>_{{ .Os  }}_{{ .Arch  }}"
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+- name_template: >-
+    {{- .ProjectName }}_
+    {{- printf "v%s" .Version }}_
+    {{- "go<< .GoVersion >>" }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ end }}
   format_overrides:
   - goos: windows
     format: zip


### PR DESCRIPTION
`archives.replacements` has been deprecated. https://goreleaser.com/deprecations/#archivesreplacements