### PR TITLE
chore: run panic(nil) test case w/o race detector

### DIFF
--- a/reporter/duration_test.go
+++ b/reporter/duration_test.go
@@ -143,24 +143,6 @@ func TestRun(t *testing.T) {
 				},
 			},
 		},
-		"child panic(nil)": {
-			fs: []func(r Reporter){
-				func(r Reporter) {},
-				func(r Reporter) {
-					panic(nil)
-				},
-			},
-			expect: result{
-				Failed: true,
-				Children: []result{
-					{},
-					{
-						Failed: true,
-						Logs:   []string{"test executed panic(nil) or runtime.Goexit"},
-					},
-				},
-			},
-		},
 		"child runtime.Goexit()": {
 			fs: []func(r Reporter){
 				func(r Reporter) {},

--- a/reporter/reporter_non_race_test.go
+++ b/reporter/reporter_non_race_test.go
@@ -1,0 +1,98 @@
+//go:build !race
+// +build !race
+
+package reporter
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TODO: This test case causes a data race in Go1.21.
+// https://github.com/golang/go/commit/213495a4a67c318a1fab6e76093e6690c2141c0e#diff-fca95769950854d54b8704162c0b104c189ed1096633227c1cbbf0c49739ccde
+func TestRun_NilPanic(t *testing.T) {
+	tests := map[string]struct {
+		maxParallel            int
+		fs                     []func(r Reporter)
+		expect                 result
+		expectSerialDuration   time.Duration
+		expectParallelDuration time.Duration
+	}{
+		"child panic(nil)": {
+			fs: []func(r Reporter){
+				func(r Reporter) {},
+				func(r Reporter) {
+					panic(nil)
+				},
+			},
+			expect: result{
+				Failed: true,
+				Children: []result{
+					{},
+					{
+						Failed: true,
+						Logs:   []string{"test executed panic(nil) or runtime.Goexit"},
+					},
+				},
+			},
+		},
+	}
+	for name, test := range tests {
+		test := test
+		opts := []Option{}
+		if test.maxParallel != 0 {
+			opts = append(opts, WithMaxParallel(test.maxParallel))
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			t.Run("serial", func(t *testing.T) {
+				t.Parallel()
+				start := time.Now()
+				r := run(func(r Reporter) {
+					for i, f := range test.fs {
+						f := f
+						r.Run(strconv.Itoa(i), func(r Reporter) {
+							f(r)
+						})
+					}
+				}, opts...)
+				duration := time.Since(start)
+				if diff := cmp.Diff(test.expect, ignoreStackTrace(collectResult(r))); diff != "" {
+					t.Errorf("result mismatch (-want +got):\n%s", diff)
+				}
+				if expect, got := test.expectSerialDuration, duration.Truncate(5*durationTestUnit); got != expect {
+					t.Errorf("expected %s but got %s", expect, got)
+				}
+				if expect, got := test.expectSerialDuration, r.getDuration().Truncate(5*durationTestUnit); got != expect {
+					t.Errorf("expected %s but got %s", expect, got)
+				}
+			})
+			t.Run("parallel", func(t *testing.T) {
+				t.Parallel()
+				start := time.Now()
+				r := run(func(r Reporter) {
+					for i, f := range test.fs {
+						f := f
+						r.Run(strconv.Itoa(i), func(r Reporter) {
+							r.Parallel()
+							f(r)
+						})
+					}
+				}, opts...)
+				duration := time.Since(start)
+				if diff := cmp.Diff(test.expect, ignoreStackTrace(collectResult(r))); diff != "" {
+					t.Errorf("result mismatch (-want +got):\n%s", diff)
+				}
+				if expect, got := test.expectParallelDuration, duration.Truncate(5*durationTestUnit); got != expect {
+					t.Errorf("expected %s but got %s", expect, got)
+				}
+				if expect, got := test.expectParallelDuration, r.getDuration().Truncate(5*durationTestUnit); got != expect {
+					t.Errorf("expected %s but got %s", expect, got)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
[The change](https://github.com/golang/go/commit/213495a4a67c318a1fab6e76093e6690c2141c0e#diff-fca95769950854d54b8704162c0b104c189ed1096633227c1cbbf0c49739ccde) may cause a data race.

https://github.com/zoncoen/scenarigo/actions/runs/6105004393/job/16567842172?pr=331