### PR TITLE
feat(config): add global variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ $ scenarigo config init
 ```yaml scenarigo.yaml
 schemaVersion: config/v1
 
+# global variables
+vars:
+  endpoint: http://api.example.com
+
 scenarios: [] # Specify test scenario files and directories.
 
 pluginDirectory: ./gen    # Specify the root directory of plugins.

--- a/runner.go
+++ b/runner.go
@@ -31,6 +31,7 @@ func init() {
 
 // Runner represents a test runner.
 type Runner struct {
+	vars            map[string]any
 	pluginDir       *string
 	plugins         schema.OrderedMap[string, schema.PluginConfig]
 	scenarioFiles   []string
@@ -66,6 +67,8 @@ func WithConfig(config *schema.Config) func(*Runner) error {
 		if config == nil {
 			return nil
 		}
+
+		r.vars = config.Vars
 
 		r.rootDir = config.Root
 		scenarios := make([]string, len(config.Scenarios))
@@ -195,6 +198,9 @@ func (r *Runner) ScenarioFiles() []string {
 // Run runs all tests.
 func (r *Runner) Run(ctx *context.Context) {
 	// setup context
+	if r.vars != nil {
+		ctx = ctx.WithVars(r.vars)
+	}
 	if r.pluginDir != nil {
 		ctx = ctx.WithPluginDir(*r.pluginDir)
 	}

--- a/runner_test.go
+++ b/runner_test.go
@@ -89,12 +89,17 @@ steps:
     method: POST
     url: "{{env.TEST_ADDR}}/echo"
     body:
-      message: "hello"
+      message: '{{vars.msg}}'
   expect:
     code: 200
     body:
       message: "hello"
 `,
+			config: &schema.Config{
+				Vars: map[string]any{
+					"msg": "hello",
+				},
+			},
 			setup: func(ctx *context.Context) func(*context.Context) {
 				mux := http.NewServeMux()
 				mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
@@ -256,6 +261,22 @@ func TestWithConfig(t *testing.T) {
 		"empty": {
 			config: &schema.Config{},
 			expect: &Runner{
+				scenarioFiles: []string{},
+				rootDir:       wd,
+			},
+		},
+		"vars": {
+			config: &schema.Config{
+				Vars: map[string]any{
+					"aaa": "foo",
+					"bbb": 123,
+				},
+			},
+			expect: &Runner{
+				vars: map[string]any{
+					"aaa": "foo",
+					"bbb": 123,
+				},
 				scenarioFiles: []string{},
 				rootDir:       wd,
 			},

--- a/schema/config.go
+++ b/schema/config.go
@@ -19,6 +19,7 @@ import (
 // Config represents a configuration.
 type Config struct {
 	SchemaVersion   string                           `yaml:"schemaVersion,omitempty"`
+	Vars            map[string]any                   `yaml:"vars,omitempty"`
 	Scenarios       []string                         `yaml:"scenarios,omitempty"`
 	PluginDirectory string                           `yaml:"pluginDirectory,omitempty"`
 	Plugins         OrderedMap[string, PluginConfig] `yaml:"plugins,omitempty"`

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -73,6 +73,9 @@ func TestE2E(t *testing.T) {
 					}
 
 					config := &schema.Config{
+						Vars: map[string]any{
+							"global": `{{"aaa"}}`,
+						},
 						PluginDirectory: "testdata/gen/plugins",
 						Plugins:         schema.NewOrderedMap[string, schema.PluginConfig](),
 					}

--- a/test/e2e/testdata/testcases/scenarios/include/included.yaml
+++ b/test/e2e/testdata/testcases/scenarios/include/included.yaml
@@ -8,7 +8,7 @@ steps:
   expect:
     code: OK
     body:
-      message: aaa
+      message: '{{vars.global}}'
   bind:
     vars:
       message: '{{response.message}}'

--- a/test/e2e/testdata/testcases/stdout/include/failure.txt
+++ b/test/e2e/testdata/testcases/stdout/include/failure.txt
@@ -17,7 +17,7 @@
                             >  9 |     code: OK
                                              ^
                               10 |     body:
-                              11 |       message: aaa
+                              11 |       message: '{{vars.global}}'
                               12 |   bind:
 FAIL
 FAIL	testdata/testcases/scenarios/include/scenario.yaml	0.000s


### PR DESCRIPTION
Add `vars` field to the config file. The defined values can be used in all scenarios.

```yaml scenarigo.yaml
schemaVersion: config/v1

# global variables
vars:
  endpoint: http://api.example.com
```
```
steps:
- title: GET /foo
  protocol: http
  request:
    method: GET
    url: '{{vars.endpoint}}/foo'
  expect:
    code: OK
```