### PR TITLE
fix(assert): fix errors when using assert.(and|or)

### DIFF
--- a/context/template.go
+++ b/context/template.go
@@ -6,5 +6,5 @@ import (
 
 // ExecuteTemplate executes template strings in context.
 func (c *Context) ExecuteTemplate(i interface{}) (interface{}, error) {
-	return template.Execute(i, c)
+	return template.Execute(c.RequestContext(), i, c)
 }

--- a/context/testdata/assertion/and.yaml
+++ b/context/testdata/assertion/and.yaml
@@ -27,17 +27,29 @@ ng:
 
 ---
 name: left arrow function w/ assertion
-yaml: |-
-  {{assert.and <-}}:
-  - "{{assert.contains <-}}":
+yaml:
+  '{{assert.and <-}}':
+  - '{{assert.contains <-}}':
       name: Alice
-  - "{{assert.contains <-}}":
-      name: Bob
+      age: '{{int($) >= 20}}'
+  - '{{assert.contains <-}}':
+      name: '{{"Bob"}}'
 ok:
 -
   - name: Alice
+    age: 20
   - name: Bob
+    age: 10
 ng:
 -
   - name: Bob
+    age: 10
   - name: Charlie
+    age: 20
+-
+  - name: Alice
+    age: 10
+  - name: Bob
+    age: 10
+  - name: Charlie
+    age: 20

--- a/context/testdata/assertion/contains.yaml
+++ b/context/testdata/assertion/contains.yaml
@@ -21,14 +21,20 @@ ng:
 
 ---
 name: left arrow function
-yaml: |-
-  {{assert.contains <-}}:
+yaml:
+  '{{assert.contains <-}}':
     name: Alice
+    age: '{{int($) > 10}}'
 ok:
 -
   - name: Alice
+    age: 20
   - name: Bob
 ng:
 -
   - name: Bob
   - name: Charlie
+-
+  - name: Alice
+    age: 10
+  - name: Bob

--- a/context/testdata/assertion/or.yaml
+++ b/context/testdata/assertion/or.yaml
@@ -24,3 +24,15 @@ ok:
 - xxx
 ng:
 - ''
+
+---
+name: left arrow function w/ assertion
+yaml:
+  '{{assert.or <-}}':
+  - xxx
+  - '{{$ == "yyy"}}'
+ok:
+- xxx
+- yyy
+ng:
+- ''

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -366,3 +366,49 @@ unexpected error: invalid b
 		}
 	})
 }
+
+func TestPathError_prependError(t *testing.T) {
+	tests := map[string]struct {
+		base   string
+		path   string
+		expect string
+	}{
+		"empty": {
+			base:   "",
+			path:   "",
+			expect: "",
+		},
+		"prepend to empty": {
+			base:   "",
+			path:   "foo",
+			expect: ".foo",
+		},
+		"key without .": {
+			base:   ".bar",
+			path:   "foo",
+			expect: ".foo.bar",
+		},
+		"key with .": {
+			base:   ".bar",
+			path:   ".foo",
+			expect: ".foo.bar",
+		},
+		"index": {
+			base:   "[1]",
+			path:   "[0]",
+			expect: "[0][1]",
+		},
+	}
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			pe := &PathError{
+				Path: test.base,
+			}
+			pe.prependPath(test.path)
+			if got, expect := pe.Path, test.expect; got != expect {
+				t.Errorf("expect %q but got %q", expect, got)
+			}
+		})
+	}
+}

--- a/template/execute_test.go
+++ b/template/execute_test.go
@@ -1,8 +1,10 @@
 package template
 
 import (
+	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/goccy/go-yaml"
 	"github.com/google/go-cmp/cmp"
@@ -294,7 +296,9 @@ func TestExecute(t *testing.T) {
 	for name, test := range tests {
 		test := test
 		t.Run(name, func(t *testing.T) {
-			got, err := Execute(test.in, test.vars)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			got, err := Execute(ctx, test.in, test.vars)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}

--- a/template/lazy.go
+++ b/template/lazy.go
@@ -1,0 +1,116 @@
+package template
+
+import (
+	"context"
+	"sync"
+
+	"github.com/zoncoen/query-go"
+	yamlextractor "github.com/zoncoen/query-go/extractor/yaml"
+
+	"github.com/zoncoen/scenarigo/errors"
+)
+
+// Lazy represents a value with lazy initialization.
+// You can create a Lazy value by using $.
+type Lazy func(any) (any, error)
+
+func (t *Template) executeLazyTemplate(ctx context.Context, data any) (any, error) {
+	wc, done := t.executeTemplate(ctx, data)
+	select {
+	case result := <-done:
+		return result.v, result.err
+	case <-wc.blocked():
+		// Delay template evaluation because the actual value is required.
+		var once sync.Once
+		return Lazy(func(v any) (any, error) {
+			var c *waitContext
+			once.Do(func() {
+				// already executing
+				c = wc
+			})
+			if c == nil {
+				// re-execution is required from the second time onwards
+				c, done = t.executeTemplate(ctx, data)
+			}
+			if err := c.set(v); err != nil {
+				return nil, err
+			}
+			result := <-done
+			return result.v, result.err
+		}), nil
+	}
+}
+
+func (t *Template) executeTemplate(ctx context.Context, data any) (*waitContext, chan templateResult) {
+	wc := newWaitContext(ctx, data)
+	done := make(chan templateResult)
+	go func() {
+		v, err := t.execute(ctx, wc)
+		done <- templateResult{
+			v:   v,
+			err: err,
+		}
+	}()
+	return wc, done
+}
+
+type templateResult struct {
+	v   any
+	err error
+}
+
+type waitContext struct {
+	any                // base data
+	extractActualValue func() (any, bool)
+	ready              chan any
+	blocked            func() <-chan struct{}
+	setOnce            sync.Once
+}
+
+func newWaitContext(ctx context.Context, base any) *waitContext {
+	block, cancel := context.WithCancel(context.Background())
+	ready := make(chan any, 1)
+	//nolint:exhaustruct
+	return &waitContext{
+		any: base,
+		extractActualValue: onceValues(func() (any, bool) {
+			cancel()
+			select {
+			case v := <-ready:
+				return v, true
+			case <-ctx.Done():
+				return nil, false
+			}
+		}),
+		ready:   ready,
+		blocked: block.Done, //nolint:contextcheck
+	}
+}
+
+func (c *waitContext) set(v any) error {
+	var first bool
+	c.setOnce.Do(func() {
+		first = true
+		c.ready <- v
+	})
+	if first {
+		return nil
+	}
+	return errors.New("set an actual value twice")
+}
+
+// ExtractByKey implements query.KeyExtractor interface.
+func (c *waitContext) ExtractByKey(key string) (any, bool) {
+	if key == "$" {
+		return c.extractActualValue()
+	}
+	k := query.New(
+		query.ExtractByStructTag("yaml", "json"),
+		query.CustomExtractFunc(yamlextractor.MapSliceExtractFunc(false)),
+	).Key(key)
+	res, err := k.Extract(c.any)
+	if err != nil {
+		return nil, false
+	}
+	return res, true
+}

--- a/template/lazy_test.go
+++ b/template/lazy_test.go
@@ -1,0 +1,132 @@
+package template
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/zoncoen/query-go"
+)
+
+func TestLazy(t *testing.T) {
+	tests := map[string]struct {
+		tmpl      string
+		data      any
+		arg       any
+		expect    any
+		expectErr string
+	}{
+		"$": {
+			tmpl:   `{{$}}`,
+			arg:    1,
+			expect: 1,
+		},
+		"$ + 1": {
+			tmpl:   `{{$ + 1}}`,
+			arg:    1,
+			expect: int64(2),
+		},
+		"$ + a": {
+			tmpl:   `{{$ + a}}`,
+			data:   map[string]any{"a": 2},
+			arg:    1,
+			expect: int64(3),
+		},
+		"$ + $": {
+			tmpl:   `{{$ + $}}`,
+			arg:    1,
+			expect: int64(2),
+		},
+		"initialization failed": {
+			tmpl:      `{{$ + 1}}`,
+			arg:       "str",
+			expect:    int64(2),
+			expectErr: `invalid operation: string(str) + int(1) not defined`,
+		},
+	}
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			v, err := Execute(ctx, test.tmpl, test.data)
+			if err != nil {
+				if test.expectErr != "" && strings.Contains(err.Error(), test.expectErr) {
+					return
+				}
+				t.Fatalf("failed to execute: %s", err)
+			}
+			lazy, ok := v.(Lazy)
+			if !ok {
+				t.Fatalf("expect Lazy but got %T", v)
+			}
+			got, err := lazy(test.arg)
+			if err != nil {
+				if test.expectErr != "" && strings.Contains(err.Error(), test.expectErr) {
+					return
+				}
+				t.Fatalf("failed to initialize lazy value: %s", err)
+			}
+			if diff := cmp.Diff(test.expect, got); diff != "" {
+				t.Errorf("diff: (-want +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWaitContext(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	wc := newWaitContext(ctx, map[string]string{"foo": "FOO"})
+	if got, expect := extractVal(t, "$.foo", wc), "FOO"; got != expect {
+		t.Fatalf("expect %q but got %q", expect, got)
+	}
+
+	// wait until setting a value
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if got, expect := extractVal(t, "$.$", wc), "BAR"; got != expect {
+			t.Errorf("expect %q but got %q", expect, got)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if got, expect := extractVal(t, "$.$", wc), "BAR"; got != expect {
+			t.Errorf("expect %q but got %q", expect, got)
+		}
+	}()
+
+	if err := wc.set("BAR"); err != nil {
+		t.Fatalf("failed to set: %s", err)
+	}
+	wg.Wait()
+
+	// extract after setting
+	if got, expect := extractVal(t, "$.$", wc), "BAR"; got != expect {
+		t.Fatalf("expect %q but got %q", expect, got)
+	}
+
+	// don't set twice
+	if err := wc.set("BAR"); err == nil {
+		t.Fatal("no error")
+	}
+}
+
+func extractVal(t *testing.T, s string, target any) any {
+	t.Helper()
+	q, err := query.ParseString(s)
+	if err != nil {
+		t.Fatalf("failed to parse query string: %s", err)
+	}
+	v, err := q.Extract(target)
+	if err != nil {
+		t.Fatalf("failed to extract: %s", err)
+	}
+	return v
+}

--- a/template/lookup.go
+++ b/template/lookup.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -15,12 +16,12 @@ type errNotDefined struct {
 	error
 }
 
-func lookup(node ast.Node, data interface{}) (interface{}, error) {
+func lookup(ctx context.Context, node ast.Node, data interface{}) (interface{}, error) {
 	v, err := extract(node, data)
 	if err != nil {
 		return nil, err
 	}
-	return Execute(v, data)
+	return Execute(ctx, v, data)
 }
 
 func extract(node ast.Node, data interface{}) (interface{}, error) {

--- a/template/once.go
+++ b/template/once.go
@@ -1,6 +1,6 @@
 //go:build go1.21
 
-package assert
+package template
 
 import "sync"
 

--- a/template/once_go_120.go
+++ b/template/once_go_120.go
@@ -5,7 +5,7 @@
 // license that can be found in the LICENSE file
 // in the Go repository.
 
-package assert
+package template
 
 import "sync"
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"reflect"
@@ -1243,7 +1244,9 @@ func runExecute(t *testing.T, tests map[string]executeTestCase) {
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
-			i, err := tmpl.Execute(test.data)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			i, err := tmpl.Execute(ctx, test.data)
 			if test.expectError == "" && err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -1368,7 +1371,9 @@ suffix: -suf
 			} else {
 				data["dump"] = &dumpFunc{}
 			}
-			v, err := tmpl.Execute(data)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			v, err := tmpl.Execute(ctx, data)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -1429,7 +1434,9 @@ func TestTemplate_ExecuteDirect(t *testing.T) {
 	for name, test := range tests {
 		test := test
 		t.Run(name, func(t *testing.T) {
-			i, err := Execute(test.i, test.data)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			i, err := Execute(ctx, test.i, test.data)
 			if !test.expectError && err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}

--- a/test/e2e/testdata/scenarios/assert.yaml
+++ b/test/e2e/testdata/scenarios/assert.yaml
@@ -49,11 +49,12 @@ steps:
     code: |-
       {{assert.and <-}}:
         - '200'
+        - '{{assert.notZero}}'
     body:
-      message: |-
-        {{assert.and <-}}:
-          - hello
-          - '{{assert.notZero}}'
+      message:
+        '{{assert.and <-}}':
+        - hello
+        - '{{assert.notZero}}'
 
 ---
 title: or
@@ -86,11 +87,12 @@ steps:
     code: |-
       {{assert.or <-}}:
         - '200'
+        - '400'
     body:
-      message: |-
-        {{assert.or <-}}:
-          - '{{"hello"}}'
-          - bye
+      message:
+        '{{assert.or <-}}':
+        - '{{"hello"}}'
+        - bye
 
 ---
 title: notZero


### PR DESCRIPTION
This change fixes the issue caused by complex assertions like the following.
```yaml
expect:
  body:
    '{{assert.and <-}}':
    - '{{assert.contains <-}}':
        name: Alice
        age: '{{int($) >= 20}}'
    - '{{assert.contains <-}}':
        name: '{{"Bob"}}'
```