### PR TITLE
fix(template): convert into string in implicit concatenation

### DIFF
--- a/template/parser/parser.go
+++ b/template/parser/parser.go
@@ -112,7 +112,7 @@ L:
 			x = &ast.BinaryExpr{
 				X:     x,
 				OpPos: pos,
-				Op:    token.ADD,
+				Op:    token.CONCAT,
 				Y:     y,
 			}
 		case token.QUESTION:

--- a/template/parser/parser_test.go
+++ b/template/parser/parser_test.go
@@ -162,7 +162,7 @@ func TestParser_Parse(t *testing.T) {
 							Rdbrace: 6,
 						},
 						OpPos: 8,
-						Op:    token.ADD,
+						Op:    token.CONCAT,
 						Y: &ast.ParameterExpr{
 							Ldbrace: 8,
 							X: &ast.Ident{
@@ -173,7 +173,7 @@ func TestParser_Parse(t *testing.T) {
 						},
 					},
 					OpPos: 15,
-					Op:    token.ADD,
+					Op:    token.CONCAT,
 					Y: &ast.ParameterExpr{
 						Ldbrace: 15,
 						X: &ast.Ident{
@@ -194,7 +194,7 @@ func TestParser_Parse(t *testing.T) {
 							Value:    "prefix-",
 						},
 						OpPos: 8,
-						Op:    token.ADD,
+						Op:    token.CONCAT,
 						Y: &ast.ParameterExpr{
 							Ldbrace: 8,
 							X: &ast.Ident{
@@ -205,7 +205,7 @@ func TestParser_Parse(t *testing.T) {
 						},
 					},
 					OpPos: 16,
-					Op:    token.ADD,
+					Op:    token.CONCAT,
 					Y: &ast.BasicLit{
 						ValuePos: 16,
 						Kind:     token.STRING,
@@ -313,7 +313,7 @@ func TestParser_Parse(t *testing.T) {
 								Value:    "\n  message: ",
 							},
 							OpPos: 26,
-							Op:    token.ADD,
+							Op:    token.CONCAT,
 							Y: &ast.ParameterExpr{
 								Ldbrace: 26,
 								X: &ast.Ident{
@@ -360,7 +360,7 @@ func TestParser_Parse(t *testing.T) {
     `,
 									},
 									OpPos: 47,
-									Op:    token.ADD,
+									Op:    token.CONCAT,
 									Y: &ast.ParameterExpr{
 										Ldbrace: 47,
 										X: &ast.LeftArrowExpr{
@@ -380,7 +380,7 @@ func TestParser_Parse(t *testing.T) {
       text: `,
 													},
 													OpPos: 94,
-													Op:    token.ADD,
+													Op:    token.CONCAT,
 													Y: &ast.ParameterExpr{
 														Ldbrace: 94,
 														X: &ast.Ident{
@@ -392,7 +392,7 @@ func TestParser_Parse(t *testing.T) {
 													},
 												},
 												OpPos: 103,
-												Op:    token.ADD,
+												Op:    token.CONCAT,
 												Y: &ast.BasicLit{
 													ValuePos: 103,
 													Kind:     token.STRING,
@@ -405,7 +405,7 @@ func TestParser_Parse(t *testing.T) {
 									},
 								},
 								OpPos: 124,
-								Op:    token.ADD,
+								Op:    token.CONCAT,
 								Y: &ast.BasicLit{
 									ValuePos: 124,
 									Kind:     token.STRING,
@@ -413,7 +413,7 @@ func TestParser_Parse(t *testing.T) {
 								},
 							},
 							OpPos: 127,
-							Op:    token.ADD,
+							Op:    token.CONCAT,
 							Y: &ast.BasicLit{
 								ValuePos: 127,
 								Kind:     token.STRING,

--- a/template/template.go
+++ b/template/template.go
@@ -269,6 +269,18 @@ func (t *Template) executeBinaryOperation(op token.Token, x, y val.Value, yExpr 
 			}
 			return oneOf(i, val.Int(1), val.Int(0))
 		}
+	case token.CONCAT:
+		if _, ok := x.(val.String); !ok {
+			if v, err := val.GetType("string").Convert(x); err == nil {
+				x = v
+			}
+		}
+		if _, ok := y.(val.String); !ok {
+			if v, err := val.GetType("string").Convert(y); err == nil {
+				y = v
+			}
+		}
+		fallthrough
 	case token.ADD:
 		if o, ok := x.(val.Adder); ok {
 			// hack for strings of left arrow functions

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -60,6 +60,10 @@ func TestTemplate_Execute(t *testing.T) {
 			str:    "prefix-{{}}-suffix",
 			expect: "prefix--suffix",
 		},
+		"implicit concatenation": {
+			str:    `{{1}}2{{3}}`,
+			expect: "123",
+		},
 		"string": {
 			str:    `{{"foo"}}`,
 			expect: "foo",

--- a/template/token/token.go
+++ b/template/token/token.go
@@ -42,6 +42,7 @@ const (
 	QUESTION  // ?
 	COLON     // :
 	LARROW    // <-
+	CONCAT    // implicit concatenation
 	LINEBREAK // end of a larrow expression argument
 
 	DEFINED // defined
@@ -116,6 +117,8 @@ func (t Token) String() string {
 		return ":"
 	case LARROW:
 		return "<-"
+	case CONCAT:
+		return "implicitly concatenate"
 	case LINEBREAK:
 		return "line break"
 	case DEFINED:


### PR DESCRIPTION
SSIA

e.g., `id-{{1}}` -> `id-1`